### PR TITLE
Test that brew man changes no files

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -710,6 +710,11 @@ module Homebrew
       return if @skip_homebrew
 
       if !@tap && (@formulae.empty? || @test_default_formula)
+        # this should always succeed
+        test "brew", "man"
+        # this succeeds if the committed manpages are up-to-date
+        test "brew", "man", "--fail-if-changed"
+
         # TODO: try to fix this on Linux at some stage.
         if OS.mac?
           # test update from origin/master to current commit.

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -710,9 +710,7 @@ module Homebrew
       return if @skip_homebrew
 
       if !@tap && (@formulae.empty? || @test_default_formula)
-        # this should always succeed
-        test "brew", "man"
-        # this succeeds if the committed manpages are up-to-date
+        # verify that manpages are up-to-date
         test "brew", "man", "--fail-if-changed"
 
         # TODO: try to fix this on Linux at some stage.


### PR DESCRIPTION
I believe that `brew man` is not part of CI. This runs it in the test-bot and verifies that it doesn't cause any changes to the tracked files. I put this very early in the test-bot loop to speed up testing, but we could put it elsewhere. I believe the master branch of brew currently will fail this test.