### PR TITLE
Run update-test --to-tag.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -717,6 +717,8 @@ module Homebrew
         if OS.mac?
           # test update from origin/master to current commit.
           test "brew", "update-test"
+          # test update from origin/master to current tag.
+          test "brew", "update-test", "--to-tag"
           # test no-op update from current commit (to current commit, a no-op).
           test "brew", "update-test", "--commit=HEAD"
         end


### PR DESCRIPTION
Use this to ensure that tag updating isn't broken.