### PR TITLE
brew-test-bot: no need to hide from manpage.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1,4 +1,3 @@
-#: @hide_from_man_page
 #:  * `test-bot` [options]  <url|formula>:
 #:    Tests the full lifecycle of a formula or Homebrew/brew change.
 #:


### PR DESCRIPTION
This is no longer needed as it's in an external repository now.