### PR TITLE
test-bot: skip if req(s) of deps are unsatisifed

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -552,7 +552,7 @@ module Homebrew
     end
 
     def satisfied_requirements?(formula, spec, dependency = nil)
-      requirements = formula.send(spec).requirements
+      requirements = formula.send(spec).recursive_requirements
 
       unsatisfied_requirements = requirements.reject do |requirement|
         satisfied = false


### PR DESCRIPTION
For example, skip a formula, rather than fail CI, if one of the
formula's dependencies has a minimum macOS requirement that's not
satisfied.

Issue Homebrew/brew#1247.
