### PR TITLE
Do not propagate keep-old flag for new formulae

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -502,7 +502,7 @@ module Homebrew
       fetch_args << "--build-bottle" if !ARGV.include?("--fast") && !ARGV.include?("--no-bottle") && !formula.bottle_disabled?
       fetch_args << "--force" if ARGV.include? "--cleanup"
 
-      new_formula = @added_formulae.include?(formula_name) ? true : false
+      new_formula = @added_formulae.include?(formula_name)
       audit_args = [formula_name]
       audit_args << "--new-formula" if new_formula
 


### PR DESCRIPTION
When brew-test-bot is called with `--keep-old` it will pass this flag to
the `bottle` command. For new formulae this results in an error.