### PR TITLE
Test or_later formula changes.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -433,7 +433,15 @@ module Homebrew
       if @tap
         formula_path = @tap.formula_dir.to_s
         @added_formulae += diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "A")
-        @modified_formula += diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "M")\
+        @modified_formula += diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "M")
+        or_later_arg = "-G    sha256 ['\"][a-f0-9]*['\"] => :\w+_or_later$"
+        unless @modified_formula.empty?
+          unless git("diff", or_later_arg, "--unified=0").strip.empty?
+            # Test rather than build bottles if we're testing a `*_or_later`
+            # bottle change.
+            ARGV << "--no-bottle"
+          end
+        end
       elsif @formulae.empty? && ARGV.include?("--test-default-formula")
         # Build the default test formula.
         HOMEBREW_CACHE_FORMULA.mkpath


### PR DESCRIPTION
When the diff contains an `or_later` bottle change then don’t try to
build the bottle but just install it and test it that way.

CC @ilovezfs for thoughts.