### PR TITLE
Use uses --recursive.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -489,7 +489,7 @@ module Homebrew
     def formula(formula_name)
       @category = "#{__method__}.#{formula_name}"
 
-      test "brew", "uses", formula_name
+      test "brew", "uses", "--recursive", formula_name
 
       formula = Formulary.factory(formula_name)
 
@@ -584,7 +584,7 @@ module Homebrew
       build_dependencies = dependencies - runtime_dependencies
       unchanged_build_dependencies = build_dependencies - @formulae
 
-      dependents = Utils.popen_read("brew", "uses", formula_name).split("\n")
+      dependents = Utils.popen_read("brew", "uses", "--recursive", formula_name).split("\n")
       dependents -= @formulae
       dependents = dependents.map { |d| Formulary.factory(d) }
 


### PR DESCRIPTION
This was removed when we were stuck on Ruby 1.8 due to terrible performance but it should now be fine to re-enable.

CC @ilovezfs for thoughts.