### PR TITLE
Update testbottest path

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -445,7 +445,7 @@ module Homebrew
       elsif @formulae.empty? && ARGV.include?("--test-default-formula")
         # Build the default test formula.
         HOMEBREW_CACHE_FORMULA.mkpath
-        testbottest = "#{HOMEBREW_LIBRARY}/Homebrew/test/testbottest.rb"
+        testbottest = "#{HOMEBREW_LIBRARY}/Homebrew/test/support/fixtures/testbottest.rb"
         FileUtils.cp testbottest, HOMEBREW_CACHE_FORMULA
         @test_default_formula = true
         @added_formulae = [testbottest]


### PR DESCRIPTION
I could have got this entirely wrong (I'm not even entirely sure how to test this!), but all of Homebrew/brew's builds seem to be failing with this error or similar:

> Error: No such file or directory - /Users/brew/Jenkins/pr-brew/version/any_sierra/Library/Homebrew/test/testbottest.rb

Homebrew/brew has a file called testbottest, but it's at Library/Homebrew/test/support/fixtures/testbottest.rb. So, my guess is that it was moved, and that's what's causing the failures.

It's very possible I'm wrong though! It looks like it's been absent since Homebrew/brew@4db1317f38f5a55574854e7bf1dfe4379e807b4f, though, so I can't guess why it only started failing very recently.