### PR TITLE
Don't run Homebrew/brew `brew readall --syntax`.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -747,7 +747,6 @@ module Homebrew
         end
 
         test "brew", "style"
-        test "brew", "readall", "--syntax"
 
         coverage_args = []
         if ARGV.include?("--coverage")


### PR DESCRIPTION
This is unnecessary now we have `brew style` and it checks whatever taps are currently tapped (which is not desirable).

CC @woodruffw 