### PR TITLE
Default --ci-auto to on for Travis CI.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1055,7 +1055,7 @@ module Homebrew
 
     travis = !ENV["TRAVIS"].nil?
     if travis
-      ARGV << "--verbose"
+      ARGV << "--verbose" << "--ci-auto"
       ENV["HOMEBREW_VERBOSE_USING_DOTS"] = "1"
     end
 


### PR DESCRIPTION
This means things like e.g. cleanup are done automatically. This is a dangerous operation but Travis CI boxes are transient anyway.