### PR TITLE
test-bot: use strict audits for updated formulae

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -515,7 +515,7 @@ module Homebrew
 
       new_formula = @added_formulae.include?(formula_name)
       audit_args = [formula_name]
-      audit_args << "--new-formula" if new_formula
+      audit_args << new_formula ? "--new-formula" : "--strict"
 
       if formula.stable
         unless satisfied_requirements?(formula, :stable)


### PR DESCRIPTION
Since the [pull request template](https://github.com/Homebrew/homebrew-core/blob/master/.github/PULL_REQUEST_TEMPLATE.md) asks contributors to run `brew audit --strict` it seems like the test-bot should do so too.