### PR TITLE
Revert "Use tap.remote for pull_pr for Linuxbrew"

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -984,7 +984,7 @@ module Homebrew
     # These variables are for Jenkins and Circle CI respectively.
     pr = ENV["UPSTREAM_PULL_REQUEST"] || ENV["CIRCLE_PR_NUMBER"]
     if pr
-      pull_pr = "#{tap.remote}/pull/#{pr}"
+      pull_pr = "https://github.com/#{tap.user}/homebrew-#{tap.repo}/pull/#{pr}"
       safe_system "brew", "pull", "--clean", pull_pr
     end
 


### PR DESCRIPTION
Follow-up to #35; see https://bot.brew.sh/job/Homebrew%20Bottles/65369/console:
```
brew pull --clean https://github.com/Homebrew/homebrew-emacs.git/pull/515
Error: Not a GitHub pull request or commit: https://github.com/Homebrew/homebrew-emacs.git/pull/515
```