### PR TITLE
Always run `brew audit strict --online`.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -519,7 +519,7 @@ module Homebrew
       fetch_args << "--force" if ARGV.include? "--cleanup"
 
       new_formula = @added_formulae.include?(formula_name)
-      audit_args = [formula_name]
+      audit_args = [formula_name, "--online"]
       audit_args << "--new-formula" if new_formula
 
       if formula.stable


### PR DESCRIPTION
As this will be an integration test doing things that require the
internet we may as well use `brew audit --online` to run any additional,
online-only tests (e.g. https://github.com/Homebrew/brew/pull/1637).