### PR TITLE
Match `brew audit` devel/head-only logic.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -910,11 +910,11 @@ module Homebrew
     end
 
     def head_only_tap?(formula)
-      formula.head && formula.devel.nil? && formula.stable.nil? && formula.tap == "homebrew/homebrew-head-only"
+      formula.head && formula.devel.nil? && formula.stable.nil? && formula.tap.to_s.downcase !~ %r{[-/]head-only$}
     end
 
     def devel_only_tap?(formula)
-      formula.devel && formula.stable.nil? && formula.tap == "homebrew/homebrew-devel-only"
+      formula.devel && formula.stable.nil? && formula.tap.to_s.downcase !~ %r{[-/]devel-only$}
     end
 
     def run


### PR DESCRIPTION
This makes more sense now we're killing our own ones of these taps.