### PR TITLE
test-bot: don't cleanup vendor

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -812,7 +812,9 @@ module Homebrew
         HOMEBREW_REPOSITORY.cd do
           safe_system "git", "checkout", "-f", "master"
           safe_system "git", "reset", "--hard", "origin/master"
-          safe_system "git", "clean", "-ffdx", "--exclude=Library/Taps"
+          safe_system "git", "clean", "-ffdx",
+            "--exclude=Library/Taps",
+            "--exclude=Library/Homebrew/vendor"
         end
       end
 


### PR DESCRIPTION
This can remove Homebrew's Ruby interpreter and break things.

/cc @MikeMcQuaid who I discussed this with.