### PR TITLE
Don't require dependencies to be linked

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -585,14 +585,6 @@ module Homebrew
       installed = Utils.popen_read("brew", "list").split("\n")
       dependencies = Utils.popen_read("brew", "deps", "--include-build", formula_name).split("\n")
 
-      (installed & dependencies).each do |installed_dependency|
-        installed_dependency_formula = Formulary.factory(installed_dependency)
-        next unless installed_dependency_formula.installed?
-        next if installed_dependency_formula.keg_only?
-        next if installed_dependency_formula.linked_keg.exist?
-        test "brew", "link", installed_dependency
-      end
-
       dependencies -= installed
       unchanged_dependencies = dependencies - @formulae
       changed_dependences = dependencies - unchanged_dependencies
@@ -1085,6 +1077,7 @@ module Homebrew
     ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
     ENV["HOMEBREW_EXPERIMENTAL_FILTER_FLAGS_ON_DEPS"] = "1"
     ENV["HOMEBREW_CHECK_RECURSIVE_VERSION_DEPENDENCIES"] = "1"
+    ENV["HOMEBREW_NO_CHECK_UNLINKED_DEPENDENCIES"] = "1"
     ENV["PATH"] = "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
 
     travis = !ENV["TRAVIS"].nil?


### PR DESCRIPTION
This should improve pull requests with lots of conflicting formulae in the same PR. Additionally, it’ll test that this linkage check isn’t required any longer.