### PR TITLE
Do not use ?override=1 when uploading to Bintray

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1054,7 +1054,6 @@ module Homebrew
 
         content_url = "https://api.bintray.com/content/#{bintray_org}"
         content_url += "/#{bintray_repo}/#{bintray_package}/#{version}/#{filename}"
-        content_url += "?override=1"
         curl "--silent", "--fail", "-u#{bintray_user}:#{bintray_key}",
              "-T", filename, content_url
         puts


### PR DESCRIPTION
The ?override=1 parameter is only needed to overwrite already published
artifacts. You can overwrite unpublished artifacts without it.