### PR TITLE
test-bot: nuke etc/var before installation.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -677,6 +677,9 @@ module Homebrew
       run_as_not_developer do
         if !ARGV.include?("--fast") || formula_bottled || formula.bottle_unneeded?
           test "brew", "install", "--only-dependencies", *install_args unless dependencies.empty?
+          # Nuke etc/var to have them be clean to detect bottle etc/var file additions.
+          FileUtils.rm_rf "#{HOMEBREW_PREFIX}/etc"
+          FileUtils.rm_rf "#{HOMEBREW_PREFIX}/var"
           test "brew", "install", *install_args
           install_passed = steps.last.passed?
         end
@@ -747,6 +750,9 @@ module Homebrew
          && satisfied_requirements?(formula, :devel)
         test "brew", "fetch", "--retry", "--devel", *fetch_args
         run_as_not_developer do
+          # Nuke etc/var to have them be clean to detect bottle etc/var file additions.
+          FileUtils.rm_rf "#{HOMEBREW_PREFIX}/etc"
+          FileUtils.rm_rf "#{HOMEBREW_PREFIX}/var"
           test "brew", "install", "--devel", formula_name, *shared_install_args
         end
         devel_install_passed = steps.last.passed?


### PR DESCRIPTION
These directories are only ever needed at runtime and we're not running anything except the main formula. The way bottle etc/var handling works assumes a clean slate before `brew install` so this becomes considerably more reliable when we just delete everything.

Worst case this introduces some weird `brew test` failure in future that mean we can `brew postinstall` (which, as-of, Homebrew/brew#2579 will reinstall configuration files) on formulae as needed if we hit that.