### PR TITLE
test-bot: handle a missing PR URL better.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -384,9 +384,10 @@ module Homebrew
       elsif ENV["JENKINS_HOME"] && ENV["GIT_URL"] && ENV["GIT_BRANCH"]
         git_url = ENV["GIT_URL"].chomp("/").chomp(".git")
         %r{origin/pr/(\d+)/(merge|head)} =~ ENV["GIT_BRANCH"]
-        pr = $1
-        @url = "#{git_url}/pull/#{pr}"
-        @hash = nil
+        if pr = $1
+          @url = "#{git_url}/pull/#{pr}"
+          @hash = nil
+        end
       # Use Circle CI pull-request variables for pull request jobs.
       elsif ENV["CI_PULL_REQUEST"] && !ENV["CI_PULL_REQUEST"].empty?
         @url = ENV["CI_PULL_REQUEST"]


### PR DESCRIPTION
Don't build a URL with a missing PR number. This may then error elsewhere depending on build type but that will be easier to understand.