### PR TITLE
test-bot: build devel as a bottle too.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -655,9 +655,9 @@ module Homebrew
       # shared_*_args are applied to both the main and --devel spec
       shared_install_args = ["--verbose"]
       shared_install_args << "--keep-tmp" if ARGV.keep_tmp?
+      shared_install_args << "--build-bottle" if !ARGV.include?("--fast") && !ARGV.include?("--no-bottle") && !formula.bottle_disabled?
       # install_args is just for the main (stable, or devel if in a devel-only tap) spec
       install_args = []
-      install_args << "--build-bottle" if !ARGV.include?("--fast") && !ARGV.include?("--no-bottle") && !formula.bottle_disabled?
       install_args << "--build-from-source" if ARGV.include?("--no-bottle")
       install_args << "--HEAD" if ARGV.include? "--HEAD"
 


### PR DESCRIPTION
Although it won't be distribute as a bottle this saves a bit of time by skipping post-install and by putting config files in `.bottle` where they can be globbed and removed by `test-bot`.