### PR TITLE
Clear tap cache before tapping

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -648,6 +648,7 @@ module Homebrew
         deps.each { |d| d.to_formula.recursive_dependencies }
       rescue TapFormulaUnavailableError => e
         raise if e.tap.installed?
+        e.tap.clear_cache
         safe_system "brew", "tap", e.tap.name
         retry
       end


### PR DESCRIPTION
Otherwise the formula path may be wrong. This is a better fix than https://github.com/Homebrew/brew/pull/2614

If you try to build a formula that depends on a formula from another tap, it may not build if the following is true:

* The other tap doesn't store formula in a `Formula/` folder
* The other tap was not yet tapped when test-bot is invoked

For example, while testing the `gazebo7` formula in https://github.com/osrf/homebrew-simulation/pull/240, I see the following console message when running `brew test-bot gazebo7` with `cartr/qt4` pre-tapped:

~~~
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::TapLoader):
 loading /usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4/qt@4.rb
~~~

It loads the formula successfully and isn't looking in the `Formula/` folder. If `cartr/qt4` is not pre-tapped, then I see the following console message, which indicates that it is looking in the `Formula/` sub-folder:

~~~
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::TapLoader):
 loading /usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4/Formula/qt@4.rb
~~~

After that, it taps `cartr/qt4`, tries to load that file (which doesn't exist because of the extra `Formula/`, and fails:

~~~
==> Tapping cartr/qt4
Cloning into '/usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4'...
remote: Counting objects: 294, done.
remote: Total 294 (delta 0), reused 0 (delta 0), pack-reused 294
Receiving objects: 100% (294/294), 59.66 KiB | 0 bytes/s, done.
Resolving deltas: 100% (186/186), done.
Checking connectivity... done.
Tapped 21 formulae (46 files, 137.1KB)
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::TapLoader): loading /usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4/Formula/qt@4.rb
Error: No available formula with the name "cartr/qt4/qt@4" 
/usr/local/Homebrew/Library/Homebrew/formulary.rb:100:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:233:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:92:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:88:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:223:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:274:in `factory'
/usr/local/Homebrew/Library/Homebrew/dependency.rb:32:in `to_formula'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/cmd/brew-test-bot.rb:599:in `block in formula'
...
~~~

In https://github.com/Homebrew/brew/pull/2614, I tracked down the place where `Formula/` was inserted in `formula_dir()` inside tap.rb and modified that, but after looking a little further with advice from @MikeMcQuaid I think the correct approach is to clear the tap cache before tapping it and retrying all the formulae.