### PR TITLE
travis.yml: remove gem cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 cache:
   directories:
-    - $HOME/.gem/ruby
+    # Re-add when the Bundler 1.15.0 issues are resolved
+    # - $HOME/.gem/ruby
     - $HOME/Library/Caches/Homebrew/style
     - $HOME/Library/Caches/Homebrew/tests
     - Library/Homebrew/vendor/bundle


### PR DESCRIPTION
While 1.15.0 is the latest Bundler and broken for us this cache seems to repeatedly poison itself so just remove it for now.