### PR TITLE
test-bot: manually run postinstall for devel.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -859,6 +859,7 @@ module Homebrew
         devel_install_passed = steps.last.passed?
         test "brew", "audit", "--devel", *audit_args
         if devel_install_passed
+          test "brew", "postinstall", formula_name
           test "brew", "test", "--devel", formula_name, *test_args if formula.test_defined?
           cleanup_bottle_etc_var(formula)
           test "brew", "uninstall", "--devel", "--force", formula_name


### PR DESCRIPTION
If postinstall has not been run, some test blocks will fail. Unlike
stable, uninstalling and then pouring the devel bottle is not currently
an option because the mismatch between the bottle version and the
formula's stable version would trigger an exception. Just removing
--build-bottle for devel is also not an option since the .bottle
directory is needed for cleanup.