### PR TITLE
.travis.yml: try new Bundler 1.15.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 cache:
   directories:
-    # Re-add when the Bundler 1.15.0 issues are resolved
-    # - $HOME/.gem/ruby
+    - $HOME/.gem/ruby
     - $HOME/Library/Caches/Homebrew/style
     - $HOME/Library/Caches/Homebrew/tests
     - $HOME/Library/Homebrew/vendor/bundle


### PR DESCRIPTION
Let's see if it'll allow itself to be cached now.