### PR TITLE
test-bot: set Git configuration name/email.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -66,11 +66,11 @@
 #:    If `--bintray-org=<bintray-org>` is passed, upload to the given Bintray
 #:    organisation.
 #:
-#:    If `--git-name=<git-name>` is passed, set the upload Git
+#:    If `--git-name=<git-name>` is passed, set the Git
 #:    author/committer names to the given name.
 #:
-#:    If `--git-email=<git-email>` is passed, set the upload Git
-#:    author/committer email to the given name.
+#:    If `--git-email=<git-email>` is passed, set the Git
+#:    author/committer email to the given email.
 #:
 #:    If `--ci-master` is passed, use the Homebrew master branch CI
 #:    options. Implies `--cleanup`: use with care!
@@ -1186,8 +1186,6 @@ module Homebrew
     first_formula_name = bottles_hash.keys.first
     tap = Tap.fetch(first_formula_name.rpartition("/").first.chuzzle || "homebrew/core")
 
-    ENV["GIT_AUTHOR_NAME"] = ENV["GIT_COMMITTER_NAME"] = ARGV.value("git-name") || "BrewTestBot"
-    ENV["GIT_AUTHOR_EMAIL"] = ENV["GIT_COMMITTER_EMAIL"] = ARGV.value("git-email") || "brew-test-bot@googlegroups.com"
     ENV["GIT_WORK_TREE"] = tap.path
     ENV["GIT_DIR"] = "#{ENV["GIT_WORK_TREE"]}/.git"
 
@@ -1343,6 +1341,12 @@ module Homebrew
     ENV["HOMEBREW_NO_EMOJI"] = "1"
     ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
     ENV["PATH"] = "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
+    ENV["GIT_AUTHOR_NAME"] =
+      ENV["GIT_COMMITTER_NAME"] =
+        ARGV.value("git-name") || "BrewTestBot"
+    ENV["GIT_AUTHOR_EMAIL"] =
+      ENV["GIT_COMMITTER_EMAIL"] =
+        ARGV.value("git-email") || "brew-test-bot@googlegroups.com"
 
     travis = !ENV["TRAVIS"].nil?
     if travis


### PR DESCRIPTION
This is needed both for `--ci-upload` and for `brew update-test` to not fail.

Also, while we're here, fix up some RuboCop failures.