### PR TITLE
test-bot: only run generic, no-compat on Linux.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -899,8 +899,11 @@ module Homebrew
 
         test "brew", "style"
 
-        test "brew", "tests", "--no-compat", "--online"
-        test "brew", "tests", "--generic", "--online"
+        if OS.linux?
+          test "brew", "tests", "--no-compat", "--online"
+          test "brew", "tests", "--generic", "--online"
+        end
+
         test "brew", "tests", "--online", *coverage_args
       elsif @tap
         test "brew", "readall", "--aliases", @tap.name


### PR DESCRIPTION
It's really slow to run these test suites three times on Travis' macOS workers but fast on their Linux ones. This should shave about 5m off our typical build time.