### PR TITLE
travis.yml: more cache changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - $HOME/Library/Caches/Homebrew/style
     - $HOME/Library/Caches/Homebrew/tests
     - $HOME/Library/Homebrew/vendor/bundle
-    - /usr/local/Homebrew/Library/Homebrew/vendor/bundle
 
 matrix:
   include:

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1043,7 +1043,7 @@ module Homebrew
         test "brew", "cleanup", "--prune=7"
         pkill_if_needed!
 
-        cleanup_shared
+        cleanup_shared unless ENV["TRAVIS"]
 
         if ARGV.include? "--local"
           FileUtils.rm_rf ENV["HOMEBREW_HOME"]


### PR DESCRIPTION
Don't cleanup the kegs we need for cache upload to work but disable the bundler caching because it seems to explode.