### PR TITLE
Use FormulaInstaller logic for satisfied reqs

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -93,6 +93,7 @@
 #:    `GIT_URL`: if set to URL of a tap remote, same as `--tap`
 
 require "formula"
+require "formula_installer"
 require "utils"
 require "date"
 require "rexml/document"
@@ -552,14 +553,8 @@ module Homebrew
     end
 
     def satisfied_requirements?(formula, spec, dependency = nil)
-      requirements = formula.send(spec).recursive_requirements
-
-      unsatisfied_requirements = requirements.reject do |requirement|
-        satisfied = false
-        satisfied ||= requirement.satisfied?
-        satisfied ||= requirement.optional?
-        satisfied
-      end
+      fi = FormulaInstaller.new(formula)
+      unsatisfied_requirements, = fi.expand_requirements
 
       if unsatisfied_requirements.empty?
         true

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -553,7 +553,8 @@ module Homebrew
     end
 
     def satisfied_requirements?(formula, spec, dependency = nil)
-      fi = FormulaInstaller.new(formula)
+      f = Formulary.factory(formula.full_name, spec)
+      fi = FormulaInstaller.new(f)
       unsatisfied_requirements, = fi.expand_requirements
 
       if unsatisfied_requirements.empty?


### PR DESCRIPTION
Use FormulaInstaller::expand_requirements in test-bot's
satisfied_requirements? function to ensure that
build requirements are ignored for formulae that
are poured from bottles.
Fixes #115.

This solution has the advantage of de-duplicating some code between `brew` and `test-bot`, but it's possible that the logic in `FormulaInstaller::expand_requirements` is supposed to differ from the test-bot `satisfied_requirements?` function. If so, then this may not be the preferred solution. Thanks for your time.