### PR TITLE
test-bot: fix or_later regex

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -530,7 +530,7 @@ module Homebrew
         unless @modified_formulae.empty?
           or_later_diff = Utils.popen_read(
             "git", "-C", @repository, "diff",
-            "-G    sha256 ['\"][a-f0-9]*['\"] => :\\w+_or_later$",
+            "-G    sha256 ['\"][a-f0-9]*['\"] => :\w+_or_later$",
             "--unified=0", diff_start_sha1, diff_end_sha1
           ).strip.empty?
 


### PR DESCRIPTION
The original regex in https://github.com/Homebrew/homebrew-test-bot/pull/20 was changed in https://github.com/Homebrew/homebrew-test-bot/blob/80333911e7130b9542a6fe2b94c1311b52cef319/cmd/brew-test-bot.rb#L530-L540.