### PR TITLE
travis.yml: fix umask for brew audit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
       HOMEBREW_CORE_TAP_DIR="$(brew --repo "homebrew/core")";
       mkdir -p "$HOMEBREW_CORE_TAP_DIR";
       ln -s .git Formula "$HOMEBREW_CORE_TAP_DIR";
+      chmod 644 Formula/*.rb;
       umask 022;
     fi
   - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"


### PR DESCRIPTION
Change the umask before we create any files to avoid `brew audit` complaining about the `chmod` of formulae.