### PR TITLE
test-bot: install gcc for devel and head if needed

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -721,7 +721,17 @@ module Homebrew
         deps.each do |dep|
           CompilerSelector.select_for(dep.to_formula)
         end
-        CompilerSelector.select_for(formula)
+        if formula.devel && formula.stable? \
+           && !ARGV.include?("--HEAD") && !ARGV.include?("--fast")
+          CompilerSelector.select_for(formula)
+          CompilerSelector.select_for(formula.devel)
+        elsif ARGV.include?("--HEAD")
+          CompilerSelector.select_for(formula.head)
+        elsif formula.stable
+          CompilerSelector.select_for(formula)
+        elsif formula.devel
+          CompilerSelector.select_for(formula.devel)
+        end
       rescue CompilerSelectionError => e
         unless installed_gcc
           run_as_not_developer { test "brew", "install", "gcc" }


### PR DESCRIPTION
Previously, only stable was able to rescue CompilerSelectionError and
install gcc automatically.