### PR TITLE
test-bot: remove default formula support.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -558,10 +558,6 @@ module Homebrew
         satisfied = false
         satisfied ||= requirement.satisfied?
         satisfied ||= requirement.optional?
-        if !satisfied && requirement.default_formula?
-          default = Formula[requirement.default_formula]
-          satisfied = satisfied_requirements?(default, :stable, formula.full_name)
-        end
         satisfied
       end
 


### PR DESCRIPTION
This is going away in https://github.com/Homebrew/brew/pull/3661.