### PR TITLE
Make Travis CI tweaks and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,61 @@
-language: ruby
-rvm: system
+language: c
 cache:
   directories:
-    - $HOME/.gem/ruby
     - $HOME/Library/Caches/Homebrew/style
     - $HOME/Library/Caches/Homebrew/tests
     - $HOME/Library/Homebrew/vendor/bundle
+branches:
+  only:
+    - master
 matrix:
+  fast_finish: true
   include:
     - os: osx
-      osx_image: xcode9
+      compiler: clang
+      osx_image: xcode9.2
     - os: linux
+      compiler: gcc
       sudo: false
 
 before_install:
-  - export HOMEBREW_NO_AUTO_UPDATE=1
-  - export HOMEBREW_DEVELOPER=1
-  - export HOMEBREW_FORCE_VENDOR_RUBY=1
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      MACOS="1";
       HOMEBREW_REPOSITORY="$(brew --repo)";
       sudo chown -R "$USER" "$HOMEBREW_REPOSITORY";
-      git -C "$HOMEBREW_REPOSITORY" fetch;
-      git -C "$HOMEBREW_REPOSITORY" reset --hard origin/master;
+      HOMEBREW_CORE_TAP_DIR="$(brew --repo "homebrew/core")";
     else
-      umask 022;
+      LINUX="1";
       HOMEBREW_REPOSITORY="$HOME/Homebrew";
-      git clone https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY";
       export PATH="$HOMEBREW_REPOSITORY/bin:$PATH";
+    fi
+  # umask 022 fixes Linux `brew tests` failures;
+  - if [ "$LINUX" ]; then
+      umask 022;
+      chmod 644 Formula/*.rb;
+    fi
+  - if [ "$MACOS" ]; then
+      travis_retry git -C "$HOMEBREW_CORE_TAP_DIR" fetch --depth=1 origin;
+    fi
+  - if [ "$MACOS" ]; then
+      travis_retry git -C "$HOMEBREW_REPOSITORY" fetch --depth=50 origin;
+    else
+      travis_retry git clone --depth=50 https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY";
+    fi
+  - if [ "$LINUX" ]; then
       HOMEBREW_CORE_TAP_DIR="$(brew --repo "homebrew/core")";
       mkdir -p "$HOMEBREW_CORE_TAP_DIR";
       ln -s .git Formula "$HOMEBREW_CORE_TAP_DIR";
-      chmod 644 Formula/*.rb;
     fi
   - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"
   - mkdir -p "$HOMEBREW_TAP_DIR"
   - rm -rf "$HOMEBREW_TAP_DIR"
   - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+  # trigger vendored ruby installation
+  - brew help
+  # can be removed after 1.5.3 is tagged
+  - if [ "$LINUX" ]; then
+      export HOMEBREW_FORCE_VENDOR_RUBY=1;
+    fi
 
 script:
   - brew test-bot

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -963,6 +963,7 @@ module Homebrew
       Tap.names.each do |tap|
         next if tap == "homebrew/core"
         next if tap == "homebrew/test-bot"
+        next if tap == "caskroom/cask"
         next if tap == @tap.to_s
         test "brew", "untap", tap
       end
@@ -1033,7 +1034,7 @@ module Homebrew
 
       if ENV["TRAVIS"]
         # For Travis CI build caching.
-        test "brew", "install", "md5deep", "libyaml" if OS.mac?
+        test "brew", "install", "md5deep", "libyaml", "gmp", "openssl" if OS.mac?
         return if @tap && @tap.to_s != "homebrew/test-bot"
       end
 


### PR DESCRIPTION
Port over the fixes from https://github.com/Homebrew/brew/pull/3736.

Additionally, don't untap Homebrew Cask (it wastes time for no benefit) and install `libgmp` for Travis CI build caching to work again.