### PR TITLE
Clone homebrew/core automatically when not present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,6 @@ before_install:
     else
       travis_retry git clone --depth=50 https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY";
     fi
-  - if [ "$LINUX" ]; then
-      HOMEBREW_CORE_TAP_DIR="$(brew --repo "homebrew/core")";
-    fi
-  - if [ "$MACOS" ]; then
-      travis_retry git -C "$HOMEBREW_CORE_TAP_DIR" fetch --depth=1 origin;
-    else
-      travis_retry git clone --depth=1 https://github.com/Homebrew/homebrew-core "$HOMEBREW_CORE_TAP_DIR";
-    fi
   - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"
   - mkdir -p "$HOMEBREW_TAP_DIR"
   - rm -rf "$HOMEBREW_TAP_DIR"

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1046,7 +1046,7 @@ module Homebrew
 
       if ENV["TRAVIS"]
         # For Travis CI build caching.
-        test "brew", "install", "md5deep", "libyaml", "gmp", "openssl" if OS.mac?
+        test "brew", "install", "md5deep", "libyaml", "gmp", "openssl@1.1" if OS.mac?
         return if @tap && @tap.to_s != "homebrew/test-bot"
       end
 

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -275,7 +275,7 @@ module Homebrew
         return
       end
 
-      if @command[0] == "git" && @command[1] != "-C"
+      if @command[0] == "git" && !%w[-C clone].include?(@command[1])
         raise "git should always be called with -C!"
       end
 
@@ -501,8 +501,20 @@ module Homebrew
       ).strip
       puts "Homebrew/brew #{brew_version} (#{brew_commit_subject})"
       if @tap.to_s != "homebrew/core"
+        core_path = CoreTap.instance.path
+        if core_path.exist?
+          if ENV["TRAVIS"]
+            test "git", "-C", core_path.to_s, "fetch", "--depth=1", "origin"
+            test "git", "-C", core_path.to_s, "reset", "--hard", "origin/master"
+          end
+        else
+          test "git", "clone", "--depth=1",
+               "https://github.com/Homebrew/homebrew-core",
+               core_path.to_s
+        end
+
         core_revision = Utils.popen_read(
-          "git", "-C", CoreTap.instance.path.to_s,
+          "git", "-C", core_path.to_s,
                  "log", "-1", "--format=%h (%s)"
         ).strip
         puts "Homebrew/homebrew-core #{core_revision}"


### PR DESCRIPTION
This means the logic can be removed from `.travis.yml` files.