### PR TITLE
test-bot: use more only-dependencies.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -649,6 +649,7 @@ module Homebrew
         test "brew", "uninstall", "--force", *@unchanged_build_dependencies
         @unchanged_dependencies -= @unchanged_build_dependencies
       end
+      test "brew", "install", "--only-dependencies", bottle_filename
       test "brew", "install", bottle_filename
     end
 
@@ -658,7 +659,10 @@ module Homebrew
         return if steps.last.failed?
         unlink_conflicts dependent
         unless ARGV.include?("--fast")
-          run_as_not_developer { test "brew", "install", dependent.name }
+          run_as_not_developer do
+            test "brew", "install", "--only-dependencies", dependent.name
+            test "brew", "install", dependent.name
+          end
           return if steps.last.failed?
         end
       end
@@ -667,12 +671,10 @@ module Homebrew
         unlink_conflicts dependent
         test "brew", "link", dependent.name
       end
+      test "brew", "install", "--only-dependencies", dependent.name
       test "brew", "linkage", "--test", dependent.name
       return unless @testable_dependents.include? dependent
-      installed = Utils.popen_read("brew", "list").split("\n")
-      test_dependencies = Utils.popen_read("brew", "deps", "--include-test", dependent.name).split("\n")
-      missing_test_dependencies = test_dependencies - installed
-      test "brew", "install", *missing_test_dependencies unless missing_test_dependencies.empty?
+      test "brew", "install", "--only-dependencies", "--include-test", dependent.name
       test "brew", "test", "--verbose", dependent.name
     end
 
@@ -840,7 +842,7 @@ module Homebrew
       install_passed = false
       run_as_not_developer do
         if !ARGV.include?("--fast") || formula_bottled || formula.bottle_unneeded?
-          test "brew", "install", "--only-dependencies", *install_args unless dependencies.empty?
+          test "brew", "install", "--only-dependencies", *install_args
           test "brew", "install", *install_args
           install_passed = steps.last.passed?
         end
@@ -872,6 +874,7 @@ module Homebrew
          && satisfied_requirements?(formula, :devel)
         test "brew", "fetch", "--retry", "--devel", *fetch_args
         run_as_not_developer do
+          test "brew", "install", "--devel", "--only-dependencies", formula_name, *shared_install_args
           test "brew", "install", "--devel", formula_name, *shared_install_args
         end
         devel_install_passed = steps.last.passed?


### PR DESCRIPTION
Now that this fills in missing dependencies it’s more useful to us.