### PR TITLE
brew-test-bot: use formula.name

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -634,7 +634,7 @@ module Homebrew
           DevelopmentTools.clear_version_cache
           retry
         end
-        skip formula_name
+        skip formula.name
         puts e.message
         return
       end


### PR DESCRIPTION
Fixes:
```
Error: undefined local variable or method `formula_name' for #<Homebrew::Test:0x00000002fb7000>
Did you mean?  formulae
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:657:in `rescue in install_gcc_if_needed'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:635:in `install_gcc_if_needed'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:889:in `formula'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:1283:in `block in run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:1282:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:1282:in `run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:1638:in `test_bot'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-test-bot/cmd/brew-test-bot.rb:1733:in `<top (required)>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3_2/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3_2/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils.rb:18:in `require?'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:107:in `<main>'
Exited with code 1
```