### PR TITLE
.travis.yml: reset HOMEBREW_REPOSITORY on macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
     fi
   - if [ "$MACOS" ]; then
       travis_retry git -C "$HOMEBREW_REPOSITORY" fetch --depth=50 origin;
+      git -C "$HOMEBREW_REPOSITORY" checkout -B master origin/master;
     else
       travis_retry git clone --depth=50 https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY";
     fi


### PR DESCRIPTION
Otherwise `brew help` will try to install an old portable Ruby.