### PR TITLE
Skip untapping `homebrew/cask`.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1074,6 +1074,7 @@ module Homebrew
         next if tap == "homebrew/core"
         next if tap == "homebrew/test-bot"
         next if tap == "caskroom/cask"
+        next if tap == "homebrew/cask"
         next if tap == @tap.to_s
         test "brew", "untap", tap
       end


### PR DESCRIPTION
Needed for https://github.com/Homebrew/brew/pull/4195.