### PR TITLE
`curl_args` does not include `curl_executable` anymore.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1426,8 +1426,8 @@ module Homebrew
           false
         else
           begin
-            system(*curl_args("-I", "--output", "/dev/null",
-                              bintray_filename_url))
+            system(curl_executable, *curl_args("-I", "--output", "/dev/null",
+                   bintray_filename_url))
           end
         end
 
@@ -1444,7 +1444,7 @@ module Homebrew
             puts "curl --output /dev/null #{package_url}"
             false
           else
-            system(*curl_args("--output", "/dev/null", package_url))
+            system(curl_executable, *curl_args("--output", "/dev/null", package_url))
           end
 
           unless package_exists


### PR DESCRIPTION
Depends on https://github.com/Homebrew/brew/pull/4569.