### PR TITLE
brew-test-bot: check build/optional for deleted formulae

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -982,6 +982,7 @@ module Homebrew
       @category = "#{__method__}.#{formula_name}"
       test "brew", "uses", "--include-build",
                            "--include-optional",
+                           "--include-test",
                            formula_name
     end
 

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -980,7 +980,9 @@ module Homebrew
 
     def deleted_formula(formula_name)
       @category = "#{__method__}.#{formula_name}"
-      test "brew", "uses", formula_name
+      test "brew", "uses", "--include-build",
+                           "--include-optional",
+                           formula_name
     end
 
     def coverage_args


### PR DESCRIPTION
There was an expectation https://github.com/Homebrew/homebrew-core/pull/31382 should be red-flagged by CI because that formula is currently a mandatory dependency, albeit at buildtime, of `elm` and consequently removing it would break `elm`, but instead CI failed to provide any warning about consequences of removing it.