### PR TITLE
Make `testbottest` URL consistent.

### DIFF
--- a/Formula/testbottest.rb
+++ b/Formula/testbottest.rb
@@ -1,7 +1,7 @@
 class Testbottest < Formula
   desc "Minimal C program and Makefile used for testing Homebrew"
   homepage "https://github.com/Homebrew/brew"
-  url "file://#{File.expand_path(__dir__)}/tarballs/testbottest-0.1.tbz"
+  url "file://#{Tap.fetch("homebrew", "test-bot").formula_dir}/tarballs/testbottest-0.1.tbz"
   sha256 "246c4839624d0b97338ce976100d56bd9331d9416e178eb0f74ef050c1dbdaad"
   head "https://github.com/Homebrew/homebrew-test-bot.git"
 


### PR DESCRIPTION
Fixes the CI failure in https://github.com/Homebrew/brew/pull/4662, since it looks up the cached file based on the URL's `sha256`.