### PR TITLE
test-bot: create necessary top-level directories.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -596,6 +596,9 @@ module Homebrew
       return if @skip_setup
       # install newer Git when needed
       test "brew", "install", "git" if OS.mac? && MacOS.version < :sierra
+      (Keg::TOP_LEVEL_DIRECTORIES + %w[opt]).each do |dir|
+        FileUtils.mkdir_p HOMEBREW_PREFIX/dir
+      end
       test "brew", "doctor"
       test "brew", "--env"
       test "brew", "config"


### PR DESCRIPTION
This ensures they have the right permissions and `brew doctor` doesn't
get upset.