### PR TITLE
test-bot: require COVERALLS_REPO_TOKEN.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,3 @@ before_install:
 
 script:
   - travis_wait 60 brew test-bot
-  - brew test-bot --ci-upload --dry-run
-  - brew test-bot --ci-pr https://github.com/Homebrew/brew/pull/4170 --dry-run
-  - brew test-bot --ci-pr https://github.com/Homebrew/brew/commit/dc96e6f73551fbadd0c2169c3a79c47a936f71ae --dry-run

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,10 +7,14 @@ jobs:
         sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
         brew update-reset /usr/local/Homebrew
         ln -s "$PWD" "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot"
-        brew test-bot --coverage
+        brew test-bot
+        brew test-bot --ci-upload --dry-run
+        brew test-bot --ci-pr https://github.com/Homebrew/brew/pull/4170 --dry-run
+        brew test-bot --ci-pr https://github.com/Homebrew/brew/commit/dc96e6f73551fbadd0c2169c3a79c47a936f71ae --dry-run
       displayName: Run brew test-bot
       env:
         HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
+        HOMEBREW_COVERALLS_REPO_TOKEN: $(coveralls.homebrewTestBotApiToken)
 
     - task: PublishTestResults@2
       displayName: Publish test-bot test results


### PR DESCRIPTION
This will allow coverage submission to be moved to Azure (which is quicker).