### PR TITLE
Copy coverage data into root.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,12 +7,15 @@ jobs:
         rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask*
         brew update-reset
         ln -s "$PWD" "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot"
-        brew test-bot
-      displayName: brew test-bot
+        brew test-bot --coverage
+      displayName: Run brew test-bot
       env:
         HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
+
     - task: PublishTestResults@2
+      displayName: Publish test-bot test results
       inputs:
+        testRunner: JUnit
         testResultsFiles: brew-test-bot.xml
 
 - job: Linux

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1017,11 +1017,6 @@ module Homebrew
                            formula_name
     end
 
-    def coverage_args
-      return [] unless ARGV.include?("--coverage")
-      ["--coverage"]
-    end
-
     def homebrew
       @category = __method__
       return if @skip_homebrew
@@ -1049,7 +1044,13 @@ module Homebrew
           test "brew", "tests", "--generic", "--online"
         end
 
-        test "brew", "tests", "--online", *coverage_args
+        if ARGV.include?("--coverage")
+          test "brew", "tests", "--online", "--coverage"
+          FileUtils.cp_r "#{HOMEBREW_REPOSITORY}/Library/Homebrew/test/coverage",
+                         Dir.pwd
+        else
+          test "brew", "tests", "--online"
+        end
       elsif @tap
         test "brew", "readall", "--aliases", @tap.name
       end


### PR DESCRIPTION
This avoids it being removed by a `git clean`.