### PR TITLE
test-bot: create cellar.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     else
       LINUX="1";
       HOMEBREW_REPOSITORY="$HOME/Homebrew";
-      export PATH="$HOMEBREW_REPOSITORY/bin:$PATH";
+      export PATH="$HOMEBREW_REPOSITORY/bin:/usr/bin:/bin";
     fi
   # umask 022 fixes Linux `brew tests` failures;
   - if [ "$LINUX" ]; then

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -597,7 +597,7 @@ module Homebrew
         ENV["HOMEBREW_FORCE_BREWED_GIT"] = "1"
       end
       (Keg::TOP_LEVEL_DIRECTORIES + %w[
-        opt lib/pkgconfig var/homebrew/linked
+        Cellar opt lib/pkgconfig var/homebrew/linked
       ]).each do |dir|
         FileUtils.mkdir_p HOMEBREW_PREFIX/dir
       end


### PR DESCRIPTION
This saves having Homebrew do it or `brew doctor` complaining.

This will not be necessary after https://github.com/Homebrew/homebrew-test-bot/pull/192 is merged.