### PR TITLE
brew-test-bot: use tap.default_remote for pull requests

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1413,7 +1413,7 @@ module Homebrew
          ENV["CHANGE_ID"] ||
          ENV["CIRCLE_PR_NUMBER"]
     if pr
-      pull_pr = "https://github.com/#{tap.user}/homebrew-#{tap.repo}/pull/#{pr}"
+      pull_pr = "#{tap.default_remote}/pull/#{pr}"
       safe_system "brew", "pull", "--clean", pull_pr
     end
 


### PR DESCRIPTION
Use `tap.default_remote` for pull requests.
CC @sjackman 