### PR TITLE
test-bot: remove brew prune.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1110,8 +1110,6 @@ module Homebrew
         reset_if_needed(git_repo)
         prune_if_needed(git_repo)
       end
-
-      test "brew", "prune"
     end
 
     def clear_stash_if_needed(repository)


### PR DESCRIPTION
This is no longer needed after https://github.com/Homebrew/brew/pull/5467 has been merged.