### PR TITLE
test-bot: remove manual CI=1 assignment.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1538,7 +1538,6 @@ module Homebrew
     end
 
     jenkins = !ENV["JENKINS_HOME"].nil?
-    ENV["CI"] = "1" if jenkins
     jenkins_pipeline_pr = jenkins && !ENV["CHANGE_URL"].nil?
     jenkins_pipeline_branch = jenkins &&
                               !jenkins_pipeline_pr &&
@@ -1549,7 +1548,6 @@ module Homebrew
     azure_pipelines = !ENV["TF_BUILD"].nil?
     if azure_pipelines
       ARGV << "--verbose" << "--ci-auto" << "--no-pull"
-      ENV["CI"] = "1"
       ENV["HOMEBREW_AZURE_PIPELINES"] = "1"
       ENV["HOMEBREW_COLOR"] = "1"
       # These cannot be queried at the macOS level on Azure Pipelines.


### PR DESCRIPTION
This is being done in https://github.com/Homebrew/brew/pull/5549 instead.