### PR TITLE
azuze-pipelines-yml: early exit on errors.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ jobs:
     vmImage: macOS-10.13
   steps:
     - bash: |
+        set -e
         sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
         brew update-reset /usr/local/Homebrew
         ln -s "$PWD" "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot"
@@ -36,6 +37,7 @@ jobs:
     vmImage: ubuntu-16.04
   steps:
     - bash: |
+        set -e
         HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew
         sudo mkdir -p /home/linuxbrew
         sudo git clone https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY"


### PR DESCRIPTION
We don't want to silently ignore failing commands.