### PR TITLE
test-bot: don't hide build bottle/from source args.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -203,8 +203,6 @@ module Homebrew
         --force
         --retry
         --verbose
-        --build-bottle
-        --build-from-source
         --json
       ].freeze).join(" ")
         .gsub(HOMEBREW_PREFIX.to_s, "")


### PR DESCRIPTION
These are useful in debugging e.g. #231.