### PR TITLE
test-bot: run generic/no-compat tests on macOS.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1020,7 +1020,7 @@ module Homebrew
 
         test "brew", "readall", "--aliases"
 
-        if OS.linux?
+        if OS.mac?
           test "brew", "tests", "--no-compat", "--online"
           test "brew", "tests", "--generic", "--online"
         end


### PR DESCRIPTION
macOS is preferable for these and Azure Pipelines doesn't have the massively slower macOS builds Travis CI had.