### PR TITLE
Revert "Remove calls to deprecated ARGV methods"

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -271,7 +271,7 @@ module Homebrew
 
       executable, *args = @command
 
-      verbose = Homebrew.args.verbose?
+      verbose = ARGV.verbose?
 
       result = system_command executable, args:         args,
                                           print_stdout: verbose,
@@ -350,11 +350,11 @@ module Homebrew
       test "brew", "tap", e.tap.name
       retry unless steps.last.failed?
       onoe e
-      puts e.backtrace if Homebrew.args.debug?
+      puts e.backtrace if ARGV.debug?
     rescue FormulaUnavailableError, TapFormulaAmbiguityError,
            TapFormulaWithOldnameAmbiguityError => e
       onoe e
-      puts e.backtrace if Homebrew.args.debug?
+      puts e.backtrace if ARGV.debug?
     end
 
     def current_sha1
@@ -888,7 +888,7 @@ module Homebrew
 
       # shared_*_args are applied to both the main and --devel spec
       shared_install_args = ["--verbose"]
-      shared_install_args << "--keep-tmp" if Homebrew.args.keep_tmp?
+      shared_install_args << "--keep-tmp" if ARGV.keep_tmp?
       if !ARGV.include?("--fast") &&
          !ARGV.include?("--no-bottle") &&
          !formula.bottle_disabled?
@@ -935,7 +935,7 @@ module Homebrew
       test "brew", "style", formula_name unless new_formula
 
       test_args = ["--verbose"]
-      test_args << "--keep-tmp" if Homebrew.args.keep_tmp?
+      test_args << "--keep-tmp" if ARGV.keep_tmp?
 
       if install_passed
         bottle_reinstall_formula(formula, new_formula)


### PR DESCRIPTION
Reverts Homebrew/homebrew-test-bot#238

@BenMusch @jonchang Unfortunately #238 wasn't quite correct; it broke verbose output due to `ARGV` being modified after the fact: https://github.com/Homebrew/homebrew-test-bot/blob/232733283f2e55c0a2b50dbd2dd784344b6d02ed/cmd/brew-test-bot.rb#L1555-L1581

I would suggest making use of `ARGV.freeze` to catch these cases (both here and in Homebrew/brew) and fix/refactor them before any more `ARGV` to `Homebrew.args` conversion is done.

Sorry! ❤️  