### PR TITLE
brew-test-bot: Enable RPATH rewriting during tests

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1543,6 +1543,10 @@ module Homebrew
       odie "cannot use --cleanup from HOMEBREW_PREFIX as it will delete all output."
     end
 
+    # This can be removed once @rpath rewriting is enabled by default.
+    # See https://github.com/Homebrew/brew/pull/5413
+    ENV["HOMEBREW_RELOCATE_METAVARS"] = "1"
+
     ENV["HOMEBREW_DEVELOPER"] = "1"
     ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
     ENV["HOMEBREW_NO_EMOJI"] = "1"


### PR DESCRIPTION
Sets `HOMEBREW_RELOCATE_METAVARS`, which instructs keg relocation on macOS to collapse all `@rpath`-prefixed install names and delete all `LC_RPATH`s from all binaries, if possible.

See https://github.com/Homebrew/brew/pull/5413

cc @sjackman 