### PR TITLE
Revert "brew-test-bot: Enable RPATH rewriting during tests"

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1543,10 +1543,6 @@ module Homebrew
       odie "cannot use --cleanup from HOMEBREW_PREFIX as it will delete all output."
     end
 
-    # This can be removed once @rpath rewriting is enabled by default.
-    # See https://github.com/Homebrew/brew/pull/5413
-    ENV["HOMEBREW_RELOCATE_METAVARS"] = "1"
-
     ENV["HOMEBREW_DEVELOPER"] = "1"
     ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
     ENV["HOMEBREW_NO_EMOJI"] = "1"


### PR DESCRIPTION
This reverts commit 30ba31514b4299735582b339cd99262bd8ed208f.

cc @scpeters 