### PR TITLE
test-bot: set HOMEBREW_FROZEN_STRING_LITERAL.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1549,6 +1549,7 @@ module Homebrew
     ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
     ENV["HOMEBREW_PATH"] = ENV["PATH"] =
                              "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
+    ENV["HOMEBREW_FROZEN_STRING_LITERAL"] = "--enable-frozen-string-literal"
 
     travis = !ENV["TRAVIS"].nil?
     circle = !ENV["CIRCLECI"].nil?


### PR DESCRIPTION
This isn't used yet but will be used shortly to test frozen literals before we enable this for Homebrew developers (then Homebrew users).