### PR TITLE
Revert "test-bot: set HOMEBREW_FROZEN_STRING_LITERAL."

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1549,7 +1549,6 @@ module Homebrew
     ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
     ENV["HOMEBREW_PATH"] = ENV["PATH"] =
                              "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
-    ENV["HOMEBREW_FROZEN_STRING_LITERAL"] = "--enable-frozen-string-literal"
 
     travis = !ENV["TRAVIS"].nil?
     circle = !ENV["CIRCLECI"].nil?


### PR DESCRIPTION
Changing the approach in https://github.com/Homebrew/brew/pull/6036 as we cannot use `--frozen-string-literal` for now due to https://bugs.ruby-lang.org/issues/12031.

Reverts Homebrew/homebrew-test-bot#247
