### PR TITLE
add HOMEBREW_NO_COLOR for Azure Pipeline

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1576,7 +1576,7 @@ module Homebrew
     if azure_pipelines
       ARGV << "--verbose" << "--ci-auto" << "--no-pull"
       ENV["HOMEBREW_AZURE_PIPELINES"] = "1"
-      ENV["HOMEBREW_COLOR"] = "1"
+      ENV["HOMEBREW_NO_COLOR"] = "1"
       # These cannot be queried at the macOS level on Azure Pipelines.
       ENV["HOMEBREW_LANGUAGES"] = "en-GB"
     end


### PR DESCRIPTION
Hi there! 

This PR adds `ENV["HOMEBREW_NO_COLOR"] = "1"` for Azure Pipeline.

Without it, the color output is broken by `<` & `>` as explained here: https://github.com/Microsoft/azure-pipelines-agent/issues/1569#issuecomment-447497620

**Live preview**

<img width="779" alt="Screenshot 2019-04-16 17 29 43" src="https://user-images.githubusercontent.com/2206544/56505465-0c380b80-651c-11e9-9ae0-62ee01e5b8d3.png">

**Detailed output view**

<img width="748" alt="Screenshot 2019-04-16 17 30 00" src="https://user-images.githubusercontent.com/2206544/56505466-0c380b80-651c-11e9-8a13-8fbcf7637489.png">

Might be better to turn it off while waiting for a fix from Azure.

Best,  
-- Ladislas
