### PR TITLE
brew test-bot --ci-upload - Push only tags to remote

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1464,10 +1464,10 @@ module Homebrew
 
     if git_tag
       if ARGV.include?("--dry-run")
-        puts "git push --force #{remote} master:master :refs/tags/#{git_tag}"
+        puts "git push --force #{remote} origin/master:master :refs/tags/#{git_tag}"
       else
-        safe_system "git", "push", "--force", remote,
-                                   "master:master", ":refs/tags/#{git_tag}"
+        safe_system "git", "push", "--force", remote, "origin/master:master",
+                                                      ":refs/tags/#{git_tag}"
       end
     end
 
@@ -1556,10 +1556,10 @@ module Homebrew
 
     if ARGV.include?("--dry-run")
       puts "git tag --force #{git_tag}"
-      puts "git push --force #{remote} master:master refs/tags/#{git_tag}"
+      puts "git push --force #{remote} origin/master:master refs/tags/#{git_tag}"
     else
       safe_system "git", "tag", "--force", git_tag
-      safe_system "git", "push", "--force", remote, "master:master",
+      safe_system "git", "push", "--force", remote, "origin/master:master",
                                                     "refs/tags/#{git_tag}"
     end
   end


### PR DESCRIPTION
Hi there!

As explained [here](https://discourse.brew.sh/t/tap-bottles-how-to-publish-after-ci-upload-to-bintray/4674), `brew test-bot --ci-upload` was pushing the changes to `master` which would then break the use of `brew pull --bottle`.

In this PR, I've removed the push of the changes to `master` but I've kept the push of the `tag`, which fixes the issue.

**BUT**, maybe this behavior is needed for your CI/CD, so the same behavior could be achieved by adding an option such as `--no-pushToMaster` or an `ENV["HOMEBREW_NO_PUSH_TO_MASTER"]`.

Let me know what you think!

Best,  
-- Ladislas

