### PR TITLE
Fix detection of modified formulae on Azure

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -413,6 +413,7 @@ module Homebrew
       elsif ENV["BUILD_REPOSITORY_URI"] && ENV["SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"]
         @url = "#{ENV["BUILD_REPOSITORY_URI"]}/pull/#{ENV["SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"]}"
         @hash = nil
+        system("git", "-C", @repository, "checkout", ENV["SYSTEM_PULLREQUEST_SOURCEBRANCH"])
       end
 
       # Use Jenkins Git plugin variables for master branch jobs.
@@ -433,7 +434,7 @@ module Homebrew
         diff_start_sha1 =
           Utils.popen_read("git", "-C", @repository, "rev-parse",
                                   "--short",
-                                  ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]).strip
+                                  "origin/#{ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]}").strip
         diff_end_sha1 = current_sha1
       # Use CircleCI Git variables.
       elsif ENV["CIRCLE_SHA1"]


### PR DESCRIPTION
On Azure, the "magic" was not happening (https://github.com/Homebrew/homebrew-test-bot/issues/251#issuecomment-486345482).

This PR fixes the issue and add a comment about `git checkout $(System.PullRequest.SourceBranch)` before calling `brew test-bot`.