### PR TITLE
test-bot: abort more core operations.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -513,6 +513,8 @@ module Homebrew
         core_path = CoreTap.instance.path
         if core_path.exist?
           if ARGV.include?("--cleanup")
+            quiet_system "git", "-C", core_path.to_s, "am", "--abort"
+            quiet_system "git", "-C", core_path.to_s, "rebase", "--abort"
             test "git", "-C", core_path.to_s, "fetch", "--depth=1", "origin"
             test "git", "-C", core_path.to_s, "reset", "--hard", "origin/master"
           end


### PR DESCRIPTION
If there's an ongoing (or, more likely, failed) `rebase` or `am` in Homebrew/homebrew-core then make sure it's cleaned up accordingly.