### PR TITLE
brew-test-bot: Add a `--skip-recursive-dependents` flag

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -88,6 +88,9 @@
 #:
 #:    If `--ci-upload` is passed, use the Homebrew CI bottle upload
 #:    options.
+#:
+#:    If `--skip-recursive-dependents` is passed, only test the direct
+#:    dependents.
 
 require "formula"
 require "formula_installer"
@@ -721,8 +724,10 @@ module Homebrew
       build_dependencies = dependencies - runtime_or_test_dependencies
       @unchanged_build_dependencies = build_dependencies - @formulae
 
+      uses_args = []
+      uses_args << "--recursive" unless ARGV.include?("--skip-recursive-dependents")
       dependents =
-        Utils.popen_read("brew", "uses", "--include-test", "--recursive", formula_name)
+        Utils.popen_read("brew", "uses", "--include-test", *uses_args, formula_name)
              .split("\n")
       dependents -= @formulae
       dependents = dependents.map { |d| Formulary.factory(d) }


### PR DESCRIPTION
- There are some _large_ formulae with many dependencies. One of these
  is `bzip2`. In those cases, we don't want to test all of its dependencies
  in one go because it times out on CI. We especially don't want to test
  all of its _recursive_ dependencies, as there are _lots_.
- We can perform manual tests of some formulae to ensure that we're
  keeping functionality, if the formuale that's depended on has made
  breaking changes to its libraries with its upgrade.