### PR TITLE
azure-pipelines: only build on Linux.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,54 +1,37 @@
-jobs:
-- job: macOS
-  pool:
-    vmImage: macOS-10.14
-  steps:
-    - bash: |
-        set -e
-        sudo xcode-select --switch /Applications/Xcode_10.2.app/Contents/Developer
-        brew update-reset /usr/local/Homebrew
-        ln -s "$PWD" "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot"
-        brew test-bot
-        brew test-bot --ci-upload --dry-run
-        brew test-bot --ci-pr https://github.com/Homebrew/brew/pull/4170 --dry-run
-        brew test-bot --ci-pr https://github.com/Homebrew/brew/commit/dc96e6f73551fbadd0c2169c3a79c47a936f71ae --dry-run
-      displayName: Run brew test-bot
-      env:
-        HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
+pool:
+  vmImage: ubuntu-16.04
 
-    - task: PublishTestResults@2
-      displayName: Publish test-bot test results
-      condition: succeededOrFailed()
-      inputs:
-        testRunner: JUnit
-        testResultsFiles: brew-test-bot.xml
+steps:
+  - bash: |
+      set -e
+      umask 022
+      if [[ -n "$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" ]]; then
+        git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/merge:pr"
+        git checkout pr
+      fi
+      HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew
+      sudo mkdir -p /home/linuxbrew
+      sudo git clone https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY"
+      sudo mkdir -p "$HOMEBREW_REPOSITORY/Library/Taps/homebrew"
+      sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-test-bot"
+      sudo chown -R "$USER" /home/linuxbrew
+      export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin"
+      brew ruby -e 'Homebrew.install_bundler_gems!'
+      sudo chmod -R og-w /home/linuxbrew /home/vsts
+    displayName: Setup Homebrew
 
-- job: Linux
-  pool:
-    vmImage: ubuntu-16.04
-  steps:
-    - bash: |
-        set -ex
-        if [[ -n "$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" ]]; then
-          git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/merge:pr"
-          git checkout pr
-        fi
-        set -u
-      displayName: Check out pull request merge commit
+  - bash: |
+      export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin"
+      umask 022
+      echo $PATH
+      brew test-bot
+    displayName: Run brew test-bot
+    env:
+      HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
 
-    - bash: |
-        docker-compose -f Dockerfile.yml build sut
-      displayName: Build Docker image
-
-    - bash: |
-        docker-compose -f Dockerfile.yml run --rm -v $(Build.ArtifactStagingDirectory):/tmp/test-bot sut
-      displayName: Run brew test-bot
-      env:
-        HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
-
-    - task: PublishTestResults@2
-      displayName: Publish test-bot test results
-      condition: succeededOrFailed()
-      inputs:
-        testRunner: JUnit
-        testResultsFiles: brew/brew-test-bot.xml
+  - task: PublishTestResults@2
+    displayName: Publish test-bot test results
+    condition: succeededOrFailed()
+    inputs:
+      testRunner: JUnit
+      testResultsFiles: brew/brew-test-bot.xml


### PR DESCRIPTION
Our main CI is now on GitHub Actions so just test on Linux (and not build a Docker image) to avoid regressions on Azure Pipelines.