### PR TITLE
Tap REQUIRED_TAPS when --tap option is specified

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -596,6 +596,13 @@ module Homebrew
       @test_brew = (!@tap || @test_bot_tap) &&
                    (@formulae.empty? || @test_default_formula)
 
+      unless @test_brew
+        installed_taps = Tap.select(&:installed?).map(&:name)
+        (REQUIRED_TAPS - installed_taps).each do |tap|
+          test "brew", "tap", tap
+        end
+      end
+
       puts <<~EOS
 
         Formula changes to be tested:


### PR DESCRIPTION
This change is mostly needed on linux. Tapping `linuxbrew/xorg` is required for some formulas and it is not done when `brew test-bot` is run with `--tap` option specified.

I didn't really give this change a test run, but if I understand the code well, it should do the job and prevent situations like this one:

https://github.com/dawidd6/homebrew-tap/commit/d6f07e80d6178260e28870f93a24a68c8cf8e43a/checks

where whole build fails because of this:
```
==> brew linkage --test dawidd6/tap/neofetch
Error: No available formula with the name "linuxbrew/xorg/xorg" 
Please tap it and then try again: brew tap linuxbrew/xorg
==> FAILED
```

and manual tapping of `linuxbrew/xorg` before build seems to fix it:

https://github.com/dawidd6/homebrew-tap/commit/4d549e4e54c34da15a142de64506888dc1d77b9e/checks