### PR TITLE
Use color in Github Actions

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1646,6 +1646,7 @@ module Homebrew
     github_actions = !ENV["GITHUB_ACTIONS"].nil?
     if github_actions
       ARGV << "--verbose" << "--ci-auto" << "--no-pull"
+      ENV["HOMEBREW_COLOR"] = "1"
       ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
       # These cannot be queried at the macOS level on GitHub Actions.
       ENV["HOMEBREW_LANGUAGES"] = "en-GB"


### PR DESCRIPTION
Looks like colorized text is showing up just fine on Github Actions:

https://github.com/dawidd6/homebrew-test/commit/585717b67f9eda62a79c69e699f50b21fff9b397/checks

I think it's worth it to make this change.