### PR TITLE
Fallback to HEAD and origin/master

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -558,6 +558,10 @@ module Homebrew
           "git", "-C", @tap.path.to_s,
                  "log", "-1", "--format=%h (%s)"
         ).strip
+        if diff_start_sha1.start_with?(diff_end_sha1) || diff_start_sha1.blank?
+          diff_start_sha1 = tap_origin_master_revision.split(" ").first
+          diff_end_sha1 = tap_revision.split(" ").first
+        end
       end
 
       puts <<~EOS


### PR DESCRIPTION
Closes: #282 

In comparison to the patch attached in issue post I added this:
```ruby
... || diff_start_sha1.blank?
```
because I forgot to set `GITHUB_BASE_REF` in local Docker container and it was set in Github Actions job. So, looks like when `GITHUB_BASE_REF` is set, `diff_start_sha1` becomes blank probably because `git merge-base` returns `fatal: Not a valid object name #{diff_end_sha1}`.

With these changes I am able to successfully run `test-bot` on Github Actions.

Successful job using these changes:
https://github.com/dawidd6/homebrew-tap/runs/237362215

Unsuccessful jobs **not** using these changes:
https://github.com/dawidd6/homebrew-tap/runs/236568969
https://github.com/dawidd6/homebrew-tap/runs/237214506

Obtaining PR patch differs between these 2 unsuccessful jobs but I think it works similarly anyway.