### PR TITLE
test-bot: fix bottled dependents testing.

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -762,10 +762,15 @@ module Homebrew
       dependents -= @formulae
       dependents = dependents.map { |d| Formulary.factory(d) }
 
-      @bottled_dependents = dependents.select(&:bottled?)
-      @testable_dependents = dependents.select do |d|
-        d.bottled? && d.test_defined?
+      if ARGV.include?("--keep-old")
+        @testable_dependents = @bottled_dependents = []
+        return
       end
+
+      @bottled_dependents = with_env(HOMEBREW_SKIP_OR_LATER_BOTTLES: "1") do
+        dependents.select(&:bottled?)
+      end
+      @testable_dependents = @bottled_dependents.select(&:test_defined?)
     end
 
     def unlink_conflicts(formula)


### PR DESCRIPTION
Ensure that we're not accepting a Mojave bottle on Catalina when testing bottled dependents. Furthermore, don't test bottled dependents at all for `--keep-old` jobs; it slows things down hugely for no benefit.