### PR TITLE
Do not check build dependents (revert #295)

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -457,7 +457,7 @@ module Homebrew
       uses_args = []
       uses_args << "--recursive" unless ARGV.include?("--skip-recursive-dependents")
       dependents =
-        Utils.popen_read("brew", "uses", "--include-build", "--include-test", *uses_args, formula_name)
+        Utils.popen_read("brew", "uses", "--include-test", *uses_args, formula_name)
              .split("\n")
       dependents -= @formulae
       dependents = dependents.map { |d| Formulary.factory(d) }


### PR DESCRIPTION
Revert #295.

We do not have enough CI power right now to test all such formulas (although we should in principle).
This is making life difficult right now for python formulas.