### PR TITLE
lib/test: uninstall bottled dependents.

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -571,7 +571,6 @@ module Homebrew
 
       unless dependent.installed?
         test "brew", "fetch", "--retry", dependent.name
-
         return if steps.last.failed?
 
         unlink_conflicts dependent
@@ -592,11 +591,13 @@ module Homebrew
       test "brew", "install", "--only-dependencies", dependent.name
       test "brew", "linkage", "--test", dependent.name
 
-      return unless @testable_dependents.include? dependent
+      if @testable_dependents.include? dependent
+        test "brew", "install", "--only-dependencies", "--include-test",
+                                dependent.name
+        test "brew", "test", "--verbose", dependent.name
+      end
 
-      test "brew", "install", "--only-dependencies", "--include-test",
-                              dependent.name
-      test "brew", "test", "--verbose", dependent.name
+      test "brew", "uninstall", "--force", dependent.name
     end
 
     def fetch_formula(fetch_args, audit_args, spec_args = [])


### PR DESCRIPTION
Expand on https://github.com/Homebrew/homebrew-test-bot/pull/306 to do further cleanup during the build (CC @Bo98 @fxcoudert).

There's no real need to keep these around; they can be reinstalled from bottles when needed and they just take up a lot of disk space.

In comparison, the `modified_formulae` need to stick around because they cannot be reinstalled from bottles after being uninstalled.