### PR TITLE
test: set HOMEBREW_BOTTLE_SUDO_PURGE.

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -489,6 +489,9 @@ module Homebrew
       return if ARGV.include?("--no-bottle")
       return if formula.bottle_disabled?
 
+      if MacOS.version >= :catalina
+        ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1"
+      end
       root_url = ARGV.value("root-url")
       bottle_args = ["--verbose", "--json", formula.name]
       bottle_args << "--keep-old" if ARGV.include?("--keep-old") && !new_formula


### PR DESCRIPTION
Set environment variable to run `sudo purge` a few times to potentially work around https://github.com/Homebrew/brew/issues/6539.

Depends on https://github.com/Homebrew/brew/pull/6931 (and my setting up `sudo purge` to run without a password on our Catalina CI nodes).