### PR TITLE
lib/test: prioritise urls over formula names

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -42,11 +42,11 @@ module Homebrew
 
       if argument == "HEAD"
         @hash = "HEAD"
-      elsif canonical_formula_name = safe_formula_canonical_name(argument)
-        @formulae = [canonical_formula_name]
       elsif url_match = argument.match(HOMEBREW_PULL_OR_COMMIT_URL_REGEX)
         @url, _, _, pr = *url_match
         @pr_url = @url if pr
+      elsif canonical_formula_name = safe_formula_canonical_name(argument)
+        @formulae = [canonical_formula_name]
       elsif quiet_system("git", "-C", @repository, "rev-parse",
                              "--verify", "-q", argument)
         @hash = argument


### PR DESCRIPTION
In #311, the check for arguments matching a safe formula canonical name was increased in priority. It is currently checked before matching against the `HOMEBREW_PULL_OR_COMMIT_URL_REGEX` (defined in [brew global.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/global.rb#L105-L106)), which [causes URL's to be passed to `Formulary.factory()`](https://github.com/Homebrew/homebrew-test-bot/blob/master/lib/test.rb#L63-L64) and spam the console with complaints about how the html in that page is not a valid formula. For example from [a recent build of mine](https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/label=osx_mojave/651/console):

~~~
+ brew test-bot --tap=osrf/simulation --root-url=https://osrf-distributions.s3.amazonaws.com/bottles-simulation --ci-pr https://github.com/osrf/homebrew-simulation/pull/959
Homebrew/homebrew-test-bot d0809c1 (Merge pull request #320 from MikeMcQuaid/test_bot_git_vars)
ARGV: --tap=osrf/simulation --root-url=https://osrf-distributions.s3.amazonaws.com/bottles-simulation --ci-pr https://github.com/osrf/homebrew-simulation/pull/959 --cleanup --test-default-formula --local --junit
==> Tapping osrf/simulation
Cloning into '/usr/local/Homebrew/Library/Taps/osrf/homebrew-simulation'...
Tapped 89 formulae (210 files, 1.5MB).
Error: 959: /Users/jenkins/Library/Caches/Homebrew/Formula/959:7: syntax error, unexpected '<'
<!DOCTYPE html>
^
/Users/jenkins/Library/Caches/Homebrew/Formula/959:8: syntax error, unexpected '<'
<html lang="en">
^
/Users/jenkins/Library/Caches/Homebrew/Formula/959:9: syntax error, unexpected '<'
  <head>
  ^
/Users/jenkins/Library/Caches/Homebrew/Formula/959:11: syntax error, unexpected '<'
  <link rel="dns-prefetch" href=...
  ^
/Users/jenkins/Library/Caches/Homebrew/Formula/959:11: syntax error, unexpected tIDENTIFIER, expecting end-of-input
  <link rel="dns-prefetch" href="https://github.githubassets...
                           ^~~~
Error: No known CI provider detected! If you are using GitHub Actions, Jenkins
ghprb-plugin, or Azure Pipelines then we cannot find the expected  environment
variables! Check you have e.g. exported them to a Docker container.

==> brew pull --clean https://github.com/osrf/homebrew-simulation/pull/959
...
~~~

This PR moves the URL regex check before the formula canonical name check, which I think is safe because I think we won't have any formula names starting with `https://github.com/`