### PR TITLE
Remove the magic merge commit logic

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -95,10 +95,6 @@ module Homebrew
       end.compact
     end
 
-    def merge_commit?(commit)
-      Utils.popen_read("git", "-C", @repository, "rev-list", "--parents", "-n1", commit).count(" ") > 1
-    end
-
     def download
       @category = __method__
       @start_branch = Utils.popen_read(
@@ -261,14 +257,8 @@ module Homebrew
         formula_path = @tap.formula_dir.to_s
         @added_formulae +=
           diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "A")
-        if OS.linux? && @tap.to_s == CoreTap.instance.name && merge_commit?(diff_end_sha1)
-          # Test formulae whose bottles were updated.
-          summaries = Utils.popen_read("git", "-C", @repository, "log", "--pretty=%s", "#{diff_start_sha1}..#{diff_end_sha1}").lines
-          @modified_formulae = summaries.map { |s| s[/^([^:]+): update .* bottle\.$/, 1] }.compact.uniq
-        else
-          @modified_formulae +=
-            diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "M")
-        end
+        @modified_formulae +=
+          diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "M")
         @deleted_formulae +=
           diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "D")
       elsif @formulae.empty? && ARGV.include?("--test-default-formula")


### PR DESCRIPTION
We no longer use this workflow in Homebrew/linuxbrew-core, so remove this special-cased merge commit logic to simplify for our current practices.