### PR TITLE
Add --override option to brew test-bot --ci-upload

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -63,6 +63,8 @@ module Homebrew
              description: "automatically pick one of the Homebrew CI options based on the environment. Implies `--cleanup`: use with care!"
       switch "--ci-upload",
              description: "use the Homebrew CI bottle upload options."
+      switch "--override",
+             description: "override already uploaded and published bottles."
       switch "--publish",
              description: "publish the uploaded bottles."
       switch "--skip-recursive-dependents",

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -265,7 +265,7 @@ module Homebrew
           content_url = "https://api.bintray.com/content/#{bintray_org}"
           content_url +=
             "/#{bintray_repo}/#{bintray_package}/#{version}/#{filename.bintray}"
-          content_url += "?publish=1" if Homebrew.args.publish?
+          content_url += "?override=1" if Homebrew.args.override?
           if Homebrew.args.dry_run?
             puts <<~EOS
               curl --user $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY
@@ -275,6 +275,29 @@ module Homebrew
           else
             curl "--user", "#{bintray_user}:#{bintray_key}",
                 "--upload-file", filename, content_url,
+                secrets: [bintray_key]
+            puts
+          end
+
+          next unless Homebrew.args.publish?
+
+          publish_url = "https://api.bintray.com/content/#{bintray_org}"
+          publish_url +=
+            "/#{bintray_repo}/#{bintray_package}/#{version}/publish"
+          publish_blob = <<~EOS
+            {"publish_wait_for_secs": 0}
+          EOS
+          if Homebrew.args.dry_run?
+            puts <<~EOS
+              curl --user $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY
+                  --header Content-Type: application/json
+                  --data #{publish_blob.delete("\n")}
+                  #{publish_url}
+            EOS
+          else
+            curl "--user", "#{bintray_user}:#{bintray_key}",
+                "--header", "Content-Type: application/json",
+                "--data", publish_blob, publish_url,
                 secrets: [bintray_key]
             puts
           end


### PR DESCRIPTION
With this option passed, `test-bot` will force overwrite already
uploaded and published bottles on Bintray.

Needed to make a separate API call for publishing,
because specifying `?override` with `?publish` in the URL didn't work as intended.

Tested cases:
- `--publish && --override` (works, overwrites bottles and publishes them)
- `--publish` (works as before)
- `--override` (works, overwrites bottles without publishing)