### PR TITLE
Add logic to handle self-hosted runners

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -83,6 +83,7 @@ module Homebrew
 
   def setup_argv_and_env
     jenkins = !ENV["JENKINS_HOME"].nil?
+    github_actions_self_hosted = !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].nil?
 
     github_actions = !ENV["GITHUB_ACTIONS"].nil?
     if github_actions
@@ -107,7 +108,8 @@ module Homebrew
        ARGV.include?("--ci-testing")
       ARGV << "--cleanup"
       ARGV << "--test-default-formula"
-      ARGV << "--local" << "--junit" if jenkins
+      ARGV << "--local" if github_actions_self_hosted || jenkins
+      ARGV << "--junit" if jenkins
     end
 
     ARGV << "--verbose" if ARGV.include?("--ci-upload")

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -882,7 +882,7 @@ module Homebrew
       @category = __method__
       return if @skip_cleanup_after
 
-      if ENV["HOMEBREW_AZURE_PIPELINES"] || ENV["HOMEBREW_GITHUB_ACTIONS"]
+      if ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
         # don't need to do post-build cleanup unless testing test-bot itself.
         return if @tap.to_s != "homebrew/test-bot"
       end


### PR DESCRIPTION
* self hosted runners need all of `cleanup_after` since the VMs are not ephemeral
* self hosted runners should modify $HOME to the runner working directory to avoid polluting the VM home directory

See https://github.com/Homebrew/homebrew-core/pull/50620 for how this affects self-hosted runners on actions.