### PR TITLE
Revert "test-bot: uninstall tested formula at the end"

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -774,7 +774,6 @@ module Homebrew
       return if @unchanged_dependencies.empty?
 
       test "brew", "uninstall", "--force", *@unchanged_dependencies
-      test "brew", "uninstall", "--force", formula_name if formula.installed?
     end
 
     def deleted_formula(formula_name)


### PR DESCRIPTION
Reverts Homebrew/homebrew-test-bot#334

This is going to break the case where you have multiple changed formula in a PR that interact (e.g. one depends on another).