### PR TITLE
test: unset HOMEBREW_DEVELOPER when building dependents from source

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -552,8 +552,9 @@ module Homebrew
 
         unlink_conflicts dependent
         test "brew", "install", "--build-from-source", "--only-dependencies",
-             dependent.full_name
-        test "brew", "install", "--build-from-source", dependent.full_name
+             dependent.full_name, env: { "HOMEBREW_DEVELOPER" => nil }
+        test "brew", "install", "--build-from-source", dependent.full_name,
+             env: { "HOMEBREW_DEVELOPER" => nil }
         return if steps.last.failed?
       end
       return unless dependent.installed?


### PR DESCRIPTION
We do this already when installing dependents from bottles: https://github.com/Homebrew/homebrew-test-bot/blob/3dc6ea64d4783be1c653bb0893acaa0fd6473e8e/lib/test.rb#L756-L759

Here's a scenario where we need it (see Homebrew/homebrew-core#51255):

* ocaml is updated, along side a revision bump for ocaml-num
* ocaml is tested first and with that, dependents are installed from source
* compcert is tried first, which has ocaml-num as a dependency
* ocaml-num is installed (via `brew install --only-dependencies`) and isn't explicitly marked as to be installed from source at this point, so an install from a bottle is attempted
* This, of course, fails (no bottle exists yet for that revision), but instead of going on to install from source, it aborts due to https://github.com/Homebrew/brew/blob/72303fb9bb5bcde82c7e0086d6b0b57b0493df62/Library/Homebrew/formula_installer.rb#L303