### PR TITLE
test: avoid building formulae twice

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -426,6 +426,8 @@ module Homebrew
         ghc
         go
         ocaml
+        ocaml-findlib
+        ocaml-num
         openjdk
         rust
       ]

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -780,6 +780,11 @@ module Homebrew
 
         @source_dependents.each do |dependent|
           install_dependent_from_source(dependent)
+
+          bottled = with_env(HOMEBREW_SKIP_OR_LATER_BOTTLES: "1") do
+            dependent.bottled?
+          end
+          install_bottled_dependent(dependent) if bottled
         end
         @bottled_dependents.each do |dependent|
           install_bottled_dependent(dependent)


### PR DESCRIPTION
Currently, it is possible that we build things twice. For example, if `ocaml` and `ocaml-findlib` are both modified in the same pull request, the sequence may be somehing like:

* Build `ocaml`.
* Test `ocaml` dependents, some of which will also depend on `ocaml-findlib`.
  - `ocaml-findlib` will be built by the `brew install --only-dependencies` step.
* `ocaml-findlib` is uninstalled and built once again, except with `--build-bottle` this time.
* Test `ocaml-findlib` dependents (which is just a subset of the `ocaml` dependents)
  - In this case there are no runtime dependencies, but there will be some duplication here for other formulae.

I initially saw this as just a build time inefficiency, but it turns out that this process has a serious effect on the bottles we produce: Homebrew/homebrew-core#51698. The `etc` and `var` part of our bottle generation process relies on there being a clean environment prior to install. This is not the case in the above scenario as `ocaml-findlib` has been previously installed and uninstalled - a process which does not delete `etc` files from the first install.

The change is to avoid duplicated dependent testing and defer dependent testing, where needed. So the above process would be like:

* Build `ocaml`.
* Test `ocaml` dependents, except those that depend on `ocaml-findlib`.
* Build `ocaml-findlib`.
* Test `ocaml-findlib` dependents (including build-time ones - we need to remember to cover them as `ocaml` would have done that as it's on the whitelist).

Example logs before and after this change in the scenario that `ocaml` and `ocaml-findlib` were modified in the same pull request:

<details>
<summary>Before</summary>

```
==> brew fetch --retry ocaml --build-bottle

==> brew uninstall --force ocaml

==> brew install --only-dependencies --verbose --build-bottle ocaml

==> brew install --verbose --build-bottle ocaml

==> brew bottle --verbose --json ocaml

==> brew linkage --test ocaml

==> brew install --only-dependencies --include-test ocaml

==> brew test ocaml --verbose

==> brew fetch --retry bibtex2html

==> brew install --build-from-source --only-dependencies bibtex2html

==> brew install --build-from-source bibtex2html

==> brew fetch --retry camlp5

==> brew install --build-from-source --only-dependencies camlp5

==> brew install --build-from-source camlp5

==> brew fetch --retry coccinelle

==> brew install --build-from-source --only-dependencies coccinelle

==> brew install --build-from-source coccinelle

==> brew fetch --retry comby

==> brew install --build-from-source --only-dependencies comby

==> brew install --build-from-source comby

==> brew fetch --retry compcert

==> brew install --build-from-source --only-dependencies compcert

==> brew install --build-from-source compcert

==> brew fetch --retry coq

==> brew install --build-from-source --only-dependencies coq

==> brew install --build-from-source coq

==> brew fetch --retry corectl

==> brew install --build-from-source --only-dependencies corectl

==> brew install --build-from-source corectl

==> brew fetch --retry dune

==> brew install --build-from-source --only-dependencies dune

==> brew install --build-from-source dune

==> brew fetch --retry flow

==> brew install --build-from-source --only-dependencies flow

==> brew install --build-from-source flow

==> brew fetch --retry haxe

==> brew install --build-from-source --only-dependencies haxe

==> brew install --build-from-source haxe

==> brew fetch --retry hevea

==> brew install --build-from-source --only-dependencies hevea

==> brew install --build-from-source hevea

==> brew fetch --retry hyperkit

==> brew install --build-from-source --only-dependencies hyperkit

==> brew install --build-from-source hyperkit

==> brew fetch --retry infer

==> brew install --build-from-source --only-dependencies infer

==> brew install --build-from-source infer

==> brew fetch --retry lablgtk

==> brew install --build-from-source --only-dependencies lablgtk

==> brew install --build-from-source lablgtk

==> brew fetch --retry ledit

==> brew install --build-from-source --only-dependencies ledit

==> brew install --build-from-source ledit

==> brew fetch --retry math-comp

==> brew install --build-from-source --only-dependencies math-comp

==> brew install --build-from-source math-comp

==> brew fetch --retry menhir

==> brew install --build-from-source --only-dependencies menhir

==> brew install --build-from-source menhir

==> brew install --only-dependencies ocaml-num

==> brew linkage --test ocaml-num

==> brew install --only-dependencies --include-test ocaml-num

==> brew test --verbose ocaml-num

==> brew uninstall --force ocaml-num

==> brew fetch --retry ocamlbuild

==> brew install --build-from-source --only-dependencies ocamlbuild

==> brew install --build-from-source ocamlbuild

==> brew fetch --retry ocamlsdl

==> brew install --build-from-source --only-dependencies ocamlsdl

==> brew install --build-from-source ocamlsdl

==> brew fetch --retry one-ml

==> brew install --build-from-source --only-dependencies one-ml

==> brew install --build-from-source one-ml

==> brew install --only-dependencies opam

==> brew linkage --test opam

==> brew install --only-dependencies --include-test opam

==> brew test --verbose opam

==> brew uninstall --force opam

==> brew fetch --retry ott

==> brew install --build-from-source --only-dependencies ott

==> brew install --build-from-source ott

==> brew fetch --retry pdfsandwich

==> brew install --build-from-source --only-dependencies pdfsandwich

==> brew install --build-from-source pdfsandwich

==> brew fetch --retry unison

==> brew install --build-from-source --only-dependencies unison

==> brew install --build-from-source unison

==> brew fetch --retry zero-install

==> brew install --build-from-source --only-dependencies zero-install

==> brew install --build-from-source zero-install

==> brew fetch --retry ocaml-findlib --build-bottle

==> brew install --only-dependencies --verbose --build-bottle ocaml-findlib

==> brew install --verbose --build-bottle ocaml-findlib

==> brew bottle --verbose --json ocaml-findlib

==> brew linkage --test ocaml-findlib

==> brew install --only-dependencies --include-test ocaml-findlib

==> brew test ocaml-findlib --verbose
```
</details>

<details>
<summary>After</summary>

```
==> brew fetch --retry ocaml --build-bottle

==> brew uninstall --force ocaml

==> brew install --only-dependencies --verbose --build-bottle ocaml

==> brew install --verbose --build-bottle ocaml

==> brew bottle --verbose --json ocaml

==> brew linkage --test ocaml

==> brew install --only-dependencies --include-test ocaml

==> brew test ocaml --verbose

==> brew fetch --retry bibtex2html

==> brew install --build-from-source --only-dependencies bibtex2html

==> brew install --build-from-source bibtex2html

==> brew fetch --retry camlp5

==> brew install --build-from-source --only-dependencies camlp5

==> brew install --build-from-source camlp5

==> brew fetch --retry coccinelle

==> brew install --build-from-source --only-dependencies coccinelle

==> brew install --build-from-source coccinelle

==> brew fetch --retry comby

==> brew install --build-from-source --only-dependencies comby

==> brew install --build-from-source comby

==> brew fetch --retry corectl

==> brew install --build-from-source --only-dependencies corectl

==> brew install --build-from-source corectl

==> brew fetch --retry dune

==> brew install --build-from-source --only-dependencies dune

==> brew install --build-from-source dune

==> brew fetch --retry flow

==> brew install --build-from-source --only-dependencies flow

==> brew install --build-from-source flow

==> brew fetch --retry haxe

==> brew install --build-from-source --only-dependencies haxe

==> brew install --build-from-source haxe

==> brew fetch --retry hevea

==> brew install --build-from-source --only-dependencies hevea

==> brew install --build-from-source hevea

==> brew fetch --retry hyperkit

==> brew install --build-from-source --only-dependencies hyperkit

==> brew install --build-from-source hyperkit

==> brew fetch --retry lablgtk

==> brew install --build-from-source --only-dependencies lablgtk

==> brew install --build-from-source lablgtk

==> brew fetch --retry ledit

==> brew install --build-from-source --only-dependencies ledit

==> brew install --build-from-source ledit

==> brew fetch --retry menhir

==> brew install --build-from-source --only-dependencies menhir

==> brew install --build-from-source menhir

==> brew fetch --retry ocamlbuild

==> brew install --build-from-source --only-dependencies ocamlbuild

==> brew install --build-from-source ocamlbuild

==> brew fetch --retry ocamlsdl

==> brew install --build-from-source --only-dependencies ocamlsdl

==> brew install --build-from-source ocamlsdl

==> brew fetch --retry one-ml

==> brew install --build-from-source --only-dependencies one-ml

==> brew install --build-from-source one-ml

==> brew install --only-dependencies opam

==> brew linkage --test opam

==> brew install --only-dependencies --include-test opam

==> brew test --verbose opam

==> brew uninstall --force opam

==> brew fetch --retry ott

==> brew install --build-from-source --only-dependencies ott

==> brew install --build-from-source ott

==> brew fetch --retry pdfsandwich

==> brew install --build-from-source --only-dependencies pdfsandwich

==> brew install --build-from-source pdfsandwich

==> brew fetch --retry unison

==> brew install --build-from-source --only-dependencies unison

==> brew install --build-from-source unison

==> brew fetch --retry zero-install

==> brew install --build-from-source --only-dependencies zero-install

==> brew install --build-from-source zero-install

==> brew fetch --retry ocaml-findlib --build-bottle

==> brew install --only-dependencies --verbose --build-bottle ocaml-findlib

==> brew install --verbose --build-bottle ocaml-findlib

==> brew bottle --verbose --json ocaml-findlib

==> brew linkage --test ocaml-findlib

==> brew install --only-dependencies --include-test ocaml-findlib

==> brew test ocaml-findlib --verbose

==> brew fetch --retry compcert

==> brew install --build-from-source --only-dependencies compcert

==> brew install --build-from-source compcert

==> brew fetch --retry coq

==> brew install --build-from-source --only-dependencies coq

==> brew install --build-from-source coq

==> brew fetch --retry infer

==> brew install --build-from-source --only-dependencies infer

==> brew install --build-from-source infer

==> brew fetch --retry math-comp

==> brew install --build-from-source --only-dependencies math-comp

==> brew install --build-from-source math-comp

==> brew install --only-dependencies ocaml-num

==> brew linkage --test ocaml-num

==> brew install --only-dependencies --include-test ocaml-num

==> brew test --verbose ocaml-num

==> brew uninstall --force ocaml-num
```
</details>

On the note of build time, some of the build time improvements could be quite large. For example, the libffi pull request (Homebrew/homebrew-core#51273) currently takes 31 hours to build, and that includes duplicating 2 hour builds of llvm, llvm@6 and llvm@7.