### PR TITLE
test: install subversion if needed

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -354,6 +354,13 @@ module Homebrew
       end
     end
 
+    def install_subversion_if_needed(deps, reqs)
+      if (deps | reqs).any? { |d| d.name == "subversion" && d.build? }
+        test "brew", "install", "subversion",
+             env: { "HOMEBREW_DEVELOPER" => nil }
+      end
+    end
+
     def setup_formulae_deps_instances(formula, formula_name)
       conflicts = formula.conflicts
       formula.recursive_dependencies.each do |dependency|
@@ -665,6 +672,7 @@ module Homebrew
       tap_needed_taps(deps)
       install_gcc_if_needed(formula, deps)
       install_mercurial_if_needed(deps, reqs)
+      install_subversion_if_needed(deps, reqs)
       setup_formulae_deps_instances(formula, formula_name)
 
       test "brew", "fetch", "--retry", *fetch_args


### PR DESCRIPTION
Should prevent situations like this (on Linux):

```
==> brew fetch --retry netpbm --build-bottle --force
==> Cloning https://svn.code.sf.net/p/netpbm/code/stable
==> Checking out 3750
You must: brew install svn
==> Retrying download
==> Cloning https://svn.code.sf.net/p/netpbm/code/stable
==> Checking out 3750
You must: brew install svn
Error: Failed to download resource "netpbm"
Failure while executing; `svn checkout https://svn.code.sf.net/p/netpbm/code/stable /github/home/.cache/Homebrew/netpbm--svn --quiet -r 3750` exited with 1. Here's the output:
You must: brew install svn


==> FAILED
```

https://github.com/Homebrew/linuxbrew-core/pull/19893/checks?check_run_id=518562926