### PR TITLE
test: build openjdk dependents from source

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -425,6 +425,7 @@ module Homebrew
         ghc
         go
         ocaml
+        openjdk
         rust
       ].include?(formula_name)
 


### PR DESCRIPTION
Request of https://github.com/Homebrew/homebrew-core/pull/51883#issuecomment-601579482

This pull request will build formulae that depend on `openjdk` from source on test-bot runs.