### PR TITLE
Revert "Add `HOMEBREW_CURL_RETRIES` to make downloads/audit more robust."

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -119,7 +119,5 @@ module Homebrew
     ENV["HOMEBREW_HOME"] = ENV["HOME"] = "#{Dir.pwd}/home"
     FileUtils.mkdir_p ENV["HOMEBREW_HOME"]
     ENV["HOMEBREW_LOGS"] = "#{Dir.pwd}/logs"
-
-    ENV["HOMEBREW_CURL_RETRIES"] = "3"
   end
 end


### PR DESCRIPTION
Reverts Homebrew/homebrew-test-bot#327.

Depends on https://github.com/Homebrew/brew/pull/7196.