### PR TITLE
test-bot: use separate API call on publish

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -267,7 +267,6 @@ module Homebrew
           content_url = "https://api.bintray.com/content/#{bintray_org}"
           content_url +=
             "/#{bintray_repo}/#{bintray_package}/#{version}/#{filename.bintray}"
-          content_url += "?publish=1" if Homebrew.args.publish?
           if Homebrew.args.dry_run?
             puts <<~EOS
               #{CURL} --user $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY
@@ -281,6 +280,15 @@ module Homebrew
             puts
           end
         end
+
+        next unless Homebrew.args.publish?
+
+        publish_url = "https://api.bintray.com/content/#{bintray_org}"
+        publish_url += "/#{bintray_repo}/#{bintray_package}/#{version}/publish"
+
+        system_curl "--user", "#{bintray_user}:#{bintray_key}",
+                    publish_url, "--request", "POST",
+                    secrets: [bintray_key]
       end
 
       return unless git_tag


### PR DESCRIPTION
We are unable to use `brew test-bot --ci-upload --publish` during the CI transition period from Jenkins to GitHub Actions.

Here I upload (but not publish) three files to Bintray.

```console
% curl --upload-file actual.tar.gz https://api.bintray.com/content/homebrew/bottles/mednafen/1.24.1/mednafen-1.24.1.catalina.bottle.tar.gz
HTTP/1.1 201 Created
{"message":"success"}
% curl --upload-file actual.tar.gz https://api.bintray.com/content/homebrew/bottles/mednafen/1.24.1/mednafen-1.24.1.mojave.bottle.tar.gz
HTTP/1.1 201 Created
{"message":"success"}
% curl --upload-file actual.tar.gz https://api.bintray.com/content/homebrew/bottles/mednafen/1.24.1/mednafen-1.24.1.high_sierra.bottle.tar.gz
HTTP/1.1 201 Created
{"message":"success"}
```

Now I wish to upload a (possibly different) file and publish it using the `?publish=1` argument.

```console
% curl --upload-file empty_test.tar.gz https://api.bintray.com/content/homebrew/bottles/mednafen/1.24.1/mednafen-1.24.1.catalina.bottle.tar.gz\?publish=1
HTTP/1.1 201 Created
{"message":"success"}
% curl --upload-file empty_test.tar.gz https://api.bintray.com/content/homebrew/bottles/mednafen/1.24.1/mednafen-1.24.1.mojave.bottle.tar.gz\?publish=1
HTTP/1.1 409 Conflict
{"message":"Unable to upload files: An artifact with the path 'mednafen-1.24.1.mojave.bottle.tar.gz' already exists"}
% curl --upload-file empty_test.tar.gz https://api.bintray.com/content/homebrew/bottles/mednafen/1.24.1/mednafen-1.24.1.high_sierra.bottle.tar.gz\?publish=1
HTTP/1.1 409 Conflict
{"message":"Unable to upload files: An artifact with the path 'mednafen-1.24.1.high_sierra.bottle.tar.gz' already exists"}
```

The `?publish=1` argument publishes all files in the same package/version combination, even if we are only uploading a single file. We haven't hit this problem before because Linuxbrew/core and third-party taps were the only consumers of the `--publish` functionality, and they were either a) only publishing a single bottle, so would never hit this race, or b) uploading and publishing one bottle at a time (i.e., no pre-existing bottles to publish).

This pull request changes this to use a separate API call (the same one from `brew pull --bottle`) to sidestep this problem.

Note that this is only necessary because Jenkins uploads but doesn't publish, with the maintainer running the publish step. However, this fix is needed in the transition period where we are supporting both Jenkins and GitHub Actions workflows.