### PR TITLE
test: add docbook-xsl to BFS whitelist

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -422,6 +422,7 @@ module Homebrew
 
       build_dependents_from_source = %w[
         cabal-install
+        docbook-xsl
         ghc
         go
         ocaml


### PR DESCRIPTION
I had hoped to get this before Homebrew/homebrew-core#51747 was merged, so let's at least try to get this in before the subsequent fixup pull requests are also merged, and restart any already-run CI jobs as needed.