### PR TITLE
test-bot: teach --publish to obey --dry-run

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -278,9 +278,16 @@ module Homebrew
         publish_url = "https://api.bintray.com/content/#{bintray_org}"
         publish_url += "/#{bintray_repo}/#{bintray_package}/#{version}/publish"
 
-        system_curl "--user", "#{bintray_user}:#{bintray_key}",
-                    publish_url, "--request", "POST",
-                    secrets: [bintray_key]
+        if Homebrew.args.dry_run?
+          puts <<~EOS
+            #{CURL} --user $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY --request POST
+                #{publish_url}
+          EOS
+        else
+          system_curl "--user", "#{bintray_user}:#{bintray_key}",
+                      publish_url, "--request", "POST",
+                      secrets: [bintray_key]
+        end
       end
 
       return unless git_tag


### PR DESCRIPTION
This prevents erroneous bottle publication when we are merely seeing what commands will be run.