### PR TITLE
test: run brew style on correct tap.

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -846,7 +846,7 @@ module Homebrew
         test "brew", "readall", "--aliases", @tap.name
         broken_xcode_rubygems = MacOS.version == :mojave &&
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
-        test "brew", "style" unless broken_xcode_rubygems
+        test "brew", "style", @tap.name unless broken_xcode_rubygems
       else
         test "brew", "readall", "--aliases"
       end


### PR DESCRIPTION
This was just run on Homebrew/brew otherwise.

CC @jonchang this is why your `brew style` violation didn't show up.