### PR TITLE
Delete unused code.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,5 @@ jobs:
     - name: Run brew test-bot --dry-run tests
       if: matrix.os == 'macOS-latest'
       run: |
-        brew test-bot --ci-upload --dry-run
-        brew test-bot --ci-pr https://github.com/Homebrew/brew/pull/4170 --dry-run
-        brew test-bot --ci-pr https://github.com/Homebrew/brew/commit/dc96e6f73551fbadd0c2169c3a79c47a936f71ae --dry-run
+        brew test-bot https://github.com/Homebrew/brew/pull/4170 --dry-run
+        brew test-bot https://github.com/Homebrew/brew/commit/dc96e6f73551fbadd0c2169c3a79c47a936f71ae --dry-run

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "activesupport"
   gem "rspec"
   gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     docile (1.3.2)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
     json (2.2.0)
+    minitest (5.14.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -22,13 +32,18 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   rspec
   simplecov
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -14,24 +14,14 @@ module Homebrew
 
       switch "--dry-run",
              description: "print what would be done rather than doing it."
-      switch "--keep-logs",
-             description: "write and keep log files under `./brewbot/`."
       switch "--cleanup",
              description: "clean all state from the Homebrew directory. Use with care!"
       switch "--skip-setup",
              description: "don't check if the local system is set up correctly."
-      switch "--junit",
-             description: "generate a JUnit XML test results file."
-      switch "--no-bottle",
-             description: "run `brew install` without `--build-bottle`."
       switch "--keep-old",
              description: "run `brew bottle --keep-old` to build new bottles for a single platform."
       switch "--skip-relocation",
              description: "run `brew bottle --skip-relocation` to build new bottles that don't require relocation."
-      switch "--HEAD",
-             description: "run `brew install` with `--HEAD`."
-      switch "--local",
-             description: "ask Homebrew to write verbose logs under `./logs/` and set `$HOME` to `./home/`"
       flag   "--tap=",
              description: "use the `git` repository of the given tap."
       switch "--fail-fast",
@@ -39,10 +29,6 @@ module Homebrew
       switch :verbose,
              description: "print test step output in real time. Has the side effect of " \
                           "passing output as raw bytes instead of re-encoding in UTF-8."
-      switch "--fast",
-             description: "don't install any packages, but run e.g. `brew audit` anyway."
-      switch "--keep-tmp",
-             description: "keep temporary files written by main installs and tests that are run."
       switch "--no-pull",
              description: "don't use `brew pull` when possible."
       switch "--test-default-formula",
@@ -55,15 +41,6 @@ module Homebrew
              description: "set the Git author/committer names to the given name."
       flag   "--git-email=",
              description: "set the Git author/committer email to the given email."
-      switch "--ci-pr",
-             description: "use the Homebrew pull request CI options. Implies `--cleanup`: use with care!"
-      switch "--ci-testing",
-             description: "use the Homebrew testing CI options. Implies `--cleanup`: use with care!"
-      switch "--ci-auto",
-             description: "automatically pick one of the Homebrew CI options based on the environment. "\
-                          "Implies `--cleanup`: use with care!"
-      switch "--ci-upload",
-             description: "use the Homebrew CI bottle upload options."
       switch "--publish",
              description: "publish the uploaded bottles."
       switch "--skip-recursive-dependents",
@@ -83,39 +60,18 @@ module Homebrew
   end
 
   def setup_argv_and_env
-    jenkins = !ENV["JENKINS_HOME"].nil?
-    github_actions_self_hosted = !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].nil?
-
-    github_actions = !ENV["GITHUB_ACTIONS"].nil?
-    if github_actions
-      ARGV << "--verbose" << "--ci-auto" << "--no-pull"
+    github_actions = ENV["GITHUB_ACTIONS"].present?
+    if ENV["GITHUB_ACTIONS"].present?
+      ARGV << "--verbose" << "--no-pull"
       ENV["HOMEBREW_COLOR"] = "1"
       ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
     end
 
-    jenkins_pr = !ENV["ghprbPullLink"].nil?
-    jenkins_pr ||= !ENV["ROOT_BUILD_CAUSE_GHPRBCAUSE"].nil?
-    github_actions_pr = ENV["GITHUB_EVENT_NAME"] == "pull_request"
-
-    if ARGV.include?("--ci-auto")
-      ARGV << if jenkins_pr || github_actions_pr
-        "--ci-pr"
-      else
-        "--ci-testing"
-      end
-    end
-
-    if ARGV.include?("--ci-pr") ||
-       ARGV.include?("--ci-testing")
+    if ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].present?
       ARGV << "--cleanup"
+    elsif github_actions
       ARGV << "--test-default-formula"
-      ARGV << "--local" if github_actions_self_hosted || jenkins
-      ARGV << "--junit" if jenkins
     end
-
-    ARGV << "--verbose" if ARGV.include?("--ci-upload")
-
-    return unless ARGV.include?("--local")
 
     ENV["HOMEBREW_HOME"] = ENV["HOME"] = "#{Dir.pwd}/home"
     FileUtils.mkdir_p ENV["HOMEBREW_HOME"]

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -4,7 +4,7 @@ module Homebrew
   # Wraps command invocations. Instantiated by Test#test.
   # Handles logging and pretty-printing.
   class Step
-    attr_reader :command, :name, :status, :output, :start_time, :end_time
+    attr_reader :command, :output
 
     # Instantiates a Step object.
     # @param test [Test] The parent Test object
@@ -12,24 +12,13 @@ module Homebrew
     # @param options [Hash] Recognized options are:
     #   :repository
     #   :env
-    #   :puts_output_on_success
-    def initialize(test, command, repository:, env: {}, puts_output_on_success: false)
+    def initialize(test, command, repository:, env: {})
       @test = test
       @category = test.category
       @command = command
-      @puts_output_on_success = puts_output_on_success
-      @name = command[1].delete("-")
       @status = :running
       @repository = repository
       @env = env
-    end
-
-    def log_file_path
-      file = "#{@category}.#{@name}.txt"
-      root = @test.log_root
-      return file unless root
-
-      root + file
     end
 
     def command_trimmed
@@ -37,25 +26,6 @@ module Homebrew
               .join(" ")
               .gsub("#{HOMEBREW_LIBRARY}/Taps/", "")
               .gsub("#{HOMEBREW_PREFIX}/", "")
-    end
-
-    def command_short
-      (@command - %W[
-        brew
-        -C
-        #{HOMEBREW_PREFIX}
-        #{HOMEBREW_REPOSITORY}
-        #{@repository}
-        #{Dir.pwd}
-        --force
-        --retry
-        --verbose
-        --json
-      ].freeze).join(" ")
-        .gsub(HOMEBREW_PREFIX.to_s, "")
-        .gsub(HOMEBREW_REPOSITORY.to_s, "")
-        .gsub(@repository.to_s, "")
-        .gsub(Dir.pwd, "")
     end
 
     def passed?
@@ -76,22 +46,12 @@ module Homebrew
     end
 
     def output?
-      @output && !@output.empty?
-    end
-
-    # The execution time of the task.
-    # Precondition: Step#run has been called.
-    # @return [Float] execution time in seconds
-    def time
-      end_time - start_time
+      @output.present?
     end
 
     def run
-      @start_time = Time.now
-
       puts_command
       if Homebrew.args.dry_run?
-        @end_time = Time.now
         @status = :passed
         puts_result
         return
@@ -108,13 +68,12 @@ module Homebrew
                                           print_stderr: verbose,
                                           env:          @env
 
-      @end_time = Time.now
       @status = result.success? ? :passed : :failed
       puts_result
 
       output = result.merged_output
 
-      unless output.empty?
+      if output.present?
         output.force_encoding(Encoding::UTF_8)
 
         @output = if output.valid_encoding?
@@ -124,8 +83,7 @@ module Homebrew
           output.encode!(Encoding::UTF_8)
         end
 
-        puts @output if (failed? || @puts_output_on_success) && !verbose
-        File.write(log_file_path, @output) if Homebrew.args.keep_logs?
+        puts @output if failed? && !verbose
       end
 
       exit 1 if Homebrew.args.fail_fast? && failed?

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -102,14 +102,9 @@ module Homebrew
         @git, "-C", @repository, "symbolic-ref", "HEAD"
       ).gsub("refs/heads/", "").strip
 
-      # Use Jenkins GitHub Pull Request Builder variables for pull request jobs.
-      if ENV["ghprbPullLink"]
-        @url = ENV["ghprbPullLink"]
-        @hash = nil
-        test @git, "-C", @repository, "checkout", "origin/master"
       # Use GitHub Actions variables for pull request jobs.
-      elsif ENV["GITHUB_REF"] && ENV["GITHUB_REPOSITORY"] &&
-            %r{refs/pull/(?<pr>\d+)/merge} =~ ENV["GITHUB_REF"]
+      if ENV["GITHUB_REF"] && ENV["GITHUB_REPOSITORY"] &&
+         %r{refs/pull/(?<pr>\d+)/merge} =~ ENV["GITHUB_REF"]
         @url = "https://github.com/#{ENV["GITHUB_REPOSITORY"]}/pull/#{pr}/checks"
         @hash = nil
       end
@@ -123,11 +118,9 @@ module Homebrew
         diff_end_sha1 = ENV["GITHUB_SHA"]
       # Otherwise just use the current SHA-1 (which may be overriden later)
       else
-        if !ENV["ghprbPullLink"] && !ENV["BOT_PARAMS"]
+        if !ENV["GITHUB_REF"] && !ENV["GITHUB_BASE_REF"]
           onoe <<~EOS
-            No known CI provider detected! If you are using GitHub Actions or Jenkins
-            ghprb-plugin, then we cannot find the expected environment
-            variables! Check you have e.g. exported them to a Docker container.
+            No known CI provider detected! If you are using GitHub Actions then we cannot find the expected  environment variables! Check you have e.g. exported them to a Docker container.
           EOS
         end
         diff_end_sha1 = diff_start_sha1 = current_sha1
@@ -142,7 +135,7 @@ module Homebrew
       diff_end_sha1 = current_sha1 if diff_end_sha1.blank?
 
       # Handle no arguments being passed on the command-line e.g.
-      #   brew test-bot`
+      #   brew test-bot
       if @hash == "HEAD"
         diff_commit_count = Utils.popen_read(
           @git, "-C", @repository, "rev-list", "--count",
@@ -154,21 +147,19 @@ module Homebrew
         else
           "#{diff_start_sha1}-#{diff_end_sha1}"
         end
-      # Handle formulae arguments being passed on the command-line or as Jenkins
-      # Testing job parameters e.g.
+      # Handle formulae arguments being passed on the command-line e.g.
       #   brew test-bot wget fish
       elsif !@formulae.empty?
         @name = "#{@formulae.first}-#{diff_end_sha1}"
         diff_start_sha1 = diff_end_sha1
-      # Handle a hash being passed on the command-line
+      # Handle a hash being passed on the command-line e.g.
       #   brew test-bot 1a2b3c
       elsif @hash
         test @git, "-C", @repository, "checkout", @hash
         diff_start_sha1 = "#{@hash}^"
         diff_end_sha1 = @hash
         @name = @hash
-      # Handle a URL being passed on the command-line or through Jenkins
-      # environment variables e.g.
+      # Handle a URL being passed on the command-line e.g.
       #   brew test-bot https://github.com/Homebrew/homebrew-core/pull/678
       elsif @url
         unless Homebrew.args.no_pull?
@@ -281,7 +272,7 @@ module Homebrew
       f = Formulary.factory(formula.full_name, spec)
       fi = FormulaInstaller.new(f)
       stable_spec = spec == :stable
-      fi.build_bottle = stable_spec && !Homebrew.args.no_bottle?
+      fi.build_bottle = stable_spec
 
       unsatisfied_requirements, = fi.expand_requirements
       return true if unsatisfied_requirements.empty?
@@ -322,19 +313,7 @@ module Homebrew
     def install_gcc_if_needed(formula, deps)
       installed_gcc = false
       deps.each { |dep| CompilerSelector.select_for(dep.to_formula) }
-      if formula.devel &&
-         formula.stable? &&
-         !Homebrew.args.HEAD? &&
-         !Homebrew.args.fast?
-        CompilerSelector.select_for(formula)
-        CompilerSelector.select_for(formula.devel)
-      elsif Homebrew.args.HEAD?
-        CompilerSelector.select_for(formula.head)
-      elsif formula.stable
-        CompilerSelector.select_for(formula)
-      elsif formula.devel
-        CompilerSelector.select_for(formula.devel)
-      end
+      CompilerSelector.select_for(formula)
     rescue CompilerSelectionError => e
       unless installed_gcc
         test "brew", "install", "gcc",
@@ -397,14 +376,12 @@ module Homebrew
       unless changed_dependencies.empty?
         test "brew", "fetch", "--retry", "--build-from-source",
                               *changed_dependencies
-        unless Homebrew.args.fast?
-          # Install changed dependencies as new bottles so we don't have
-          # checksum problems.
-          test "brew", "install", "--build-from-source", *changed_dependencies
-          # Run postinstall on them because the tested formula might depend on
-          # this step
-          test "brew", "postinstall", *changed_dependencies
-        end
+        # Install changed dependencies as new bottles so we don't have
+        # checksum problems.
+        test "brew", "install", "--build-from-source", *changed_dependencies
+        # Run postinstall on them because the tested formula might depend on
+        # this step
+        test "brew", "postinstall", *changed_dependencies
       end
 
       runtime_or_test_dependencies =
@@ -521,9 +498,6 @@ module Homebrew
     end
 
     def bottle_reinstall_formula(formula, new_formula)
-      return unless formula.stable?
-      return if Homebrew.args.fast?
-      return if Homebrew.args.no_bottle?
       return if formula.bottle_disabled?
 
       ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if MacOS.version >= :catalina
@@ -576,7 +550,7 @@ module Homebrew
     end
 
     def install_dependent_from_source(dependent)
-      return if Homebrew.args.fast? || !satisfied_requirements?(dependent, :stable)
+      return unless satisfied_requirements?(dependent, :stable)
 
       if dependent.deprecated? || dependent.disabled?
         verb = dependent.deprecated? ? :deprecated : :disabled
@@ -633,13 +607,12 @@ module Homebrew
         return if steps.last.failed?
 
         unlink_conflicts dependent
-        unless Homebrew.args.fast?
-          test "brew", "install", "--only-dependencies", dependent.full_name,
-               env: { "HOMEBREW_DEVELOPER" => nil }
-          test "brew", "install", dependent.full_name,
-               env: { "HOMEBREW_DEVELOPER" => nil }
-          return if steps.last.failed?
-        end
+
+        test "brew", "install", "--only-dependencies", dependent.full_name,
+              env: { "HOMEBREW_DEVELOPER" => nil }
+        test "brew", "install", dependent.full_name,
+              env: { "HOMEBREW_DEVELOPER" => nil }
+        return if steps.last.failed?
       end
       return unless dependent.installed?
 
@@ -681,12 +654,9 @@ module Homebrew
       reqs = []
 
       fetch_args = [formula_name]
-      if !Homebrew.args.fast? &&
-         !Homebrew.args.no_bottle? &&
-         !formula.bottle_disabled?
-        fetch_args << "--build-bottle"
-      end
+      fetch_args << "--build-bottle" unless formula.bottle_disabled?
       fetch_args << "--force" if Homebrew.args.cleanup?
+
       new_formula = @added_formulae.include?(formula_name)
       audit_args = [formula_name, "--online"]
       if new_formula
@@ -697,24 +667,13 @@ module Homebrew
         end
       end
 
-      if formula.stable
-        unless satisfied_requirements?(formula, :stable)
-          fetch_formula(fetch_args, audit_args)
-          return
-        end
+      unless satisfied_requirements?(formula, :stable)
+        fetch_formula(fetch_args, audit_args)
+        return
+      end
 
-        deps |= formula.stable.deps.to_a.reject(&:optional?)
-        reqs |= formula.stable.requirements.to_a.reject(&:optional?)
-      elsif formula.devel
-        unless satisfied_requirements?(formula, :devel)
-          fetch_formula(fetch_args, audit_args, ["--devel"])
-          return
-        end
-      end
-      if formula.devel && !Homebrew.args.HEAD?
-        deps |= formula.devel.deps.to_a.reject(&:optional?)
-        reqs |= formula.devel.requirements.to_a.reject(&:optional?)
-      end
+      deps |= formula.deps.to_a.reject(&:optional?)
+      reqs |= formula.requirements.to_a.reject(&:optional?)
 
       tap_needed_taps(deps)
       install_gcc_if_needed(formula, deps)
@@ -725,40 +684,13 @@ module Homebrew
       test "brew", "fetch", "--retry", *fetch_args
       test "brew", "uninstall", "--force", formula_name if formula.installed?
 
-      # shared_*_args are applied to both the main and --devel spec
-      shared_install_args = ["--verbose"]
-      shared_install_args << "--keep-tmp" if Homebrew.args.keep_tmp?
-      if !Homebrew.args.fast? &&
-         !Homebrew.args.no_bottle? &&
-         !formula.bottle_disabled?
-        shared_install_args << "--build-bottle"
-      end
-
-      # install_args is just for the main (stable, or devel if in a devel-only
-      # tap) spec
-      install_args = []
-      install_args << "--HEAD" if Homebrew.args.HEAD?
-
-      # Pass --devel or --HEAD to install in the event formulae lack stable.
-      # Supports devel-only/head-only.
-      # head-only should not have devel, but devel-only can have head.
-      # Stable can have all three.
-      formula_bottled = if devel_only_tap? formula
-        install_args << "--devel"
-        false
-      elsif head_only_tap? formula
-        install_args << "--HEAD"
-        false
-      else
-        formula.bottled?
-      end
-
-      install_args += shared_install_args
+      install_args = ["--verbose"]
+      install_args << "--build-bottle" unless formula.bottle_disabled?
       install_args << formula_name
 
       # Don't care about e.g. bottle failures for dependencies.
       install_passed = false
-      if !Homebrew.args.fast? || formula_bottled || formula.bottle_unneeded?
+      if formula.bottled? || formula.bottle_unneeded?
         test "brew", "install", "--only-dependencies", *install_args,
              env: { "HOMEBREW_DEVELOPER" => nil }
         test "brew", "install", *install_args,
@@ -769,9 +701,6 @@ module Homebrew
 
       test "brew", "audit", "--skip-style", *audit_args
 
-      test_args = ["--verbose"]
-      test_args << "--keep-tmp" if Homebrew.args.keep_tmp?
-
       if install_passed
         bottle_reinstall_formula(formula, new_formula)
         test "brew", "linkage", "--test", formula_name
@@ -779,7 +708,7 @@ module Homebrew
         if formula.test_defined?
           test "brew", "install", "--only-dependencies", "--include-test",
                                   formula_name
-          test "brew", "test", formula_name, *test_args
+          test "brew", "test", "--verbose", formula_name
         end
 
         @source_dependents.each do |dependent|
@@ -794,35 +723,6 @@ module Homebrew
           install_bottled_dependent(dependent)
         end
         cleanup_bottle_etc_var(formula)
-      end
-
-      if formula.devel &&
-         formula.stable? &&
-         !Homebrew.args.HEAD? &&
-         !Homebrew.args.fast? &&
-         satisfied_requirements?(formula, :devel)
-        test "brew", "uninstall", "--force", formula_name if formula.installed?
-
-        test "brew", "fetch", "--retry", "--devel", *fetch_args
-
-        test "brew", "install", "--devel", "--only-dependencies", formula_name, *shared_install_args,
-             env: { "HOMEBREW_DEVELOPER" => nil }
-        test "brew", "install", "--devel", formula_name, *shared_install_args,
-             env: { "HOMEBREW_DEVELOPER" => nil }
-        devel_install_passed = steps.last.passed?
-
-        if devel_install_passed
-          test "brew", "postinstall", formula_name
-
-          if formula.test_defined?
-            test "brew", "install", "--devel", "--only-dependencies",
-                                    "--include-test", formula_name
-            test "brew", "test", "--devel", formula_name, *test_args
-          end
-
-          cleanup_bottle_etc_var(formula)
-          test "brew", "uninstall", "--force", formula_name
-        end
       end
 
       return if @unchanged_dependencies.empty?
@@ -841,15 +741,12 @@ module Homebrew
     def readall
       @category = __method__
       return if @skip_homebrew
+      return unless @tap
 
-      if @tap
-        test "brew", "readall", "--aliases", @tap.name
-        broken_xcode_rubygems = MacOS.version == :mojave &&
-                                MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
-        test "brew", "style", @tap.name unless broken_xcode_rubygems
-      else
-        test "brew", "readall", "--aliases"
-      end
+      test "brew", "readall", "--aliases", @tap.name
+      broken_xcode_rubygems = MacOS.version == :mojave &&
+                              MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
+      test "brew", "style", @tap.name unless broken_xcode_rubygems
     end
 
     def cleanup_git_meta(repository)
@@ -1019,8 +916,6 @@ module Homebrew
           FileUtils.rm_rf ENV["HOMEBREW_LOGS"]
         end
       end
-
-      FileUtils.rm_rf @brewbot_root unless Homebrew.args.keep_logs?
     end
 
     def cleanup_during
@@ -1045,16 +940,6 @@ module Homebrew
       step.run
       steps << step
       step
-    end
-
-    def check_results
-      steps.all? do |step|
-        case step.status
-        when :passed  then true
-        when :running then raise
-        when :failed  then false
-        end
-      end
     end
 
     def formulae
@@ -1093,21 +978,6 @@ module Homebrew
       changed_formulae + unchanged_formulae
     end
 
-    def head_only_tap?(formula)
-      return false unless formula.head
-      return false if formula.devel
-      return false if formula.stable
-
-      formula.tap.to_s.downcase !~ %r{[-/]head-only$}
-    end
-
-    def devel_only_tap?(formula)
-      return false unless formula.devel
-      return false if formula.stable
-
-      formula.tap.to_s.downcase !~ %r{[-/]devel-only$}
-    end
-
     def run
       @formulae_that_have_been_built = []
       cleanup_before
@@ -1124,7 +994,6 @@ module Homebrew
       ensure
         cleanup_after
       end
-      check_results
     end
   end
 end

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -5,9 +5,6 @@ require_relative "test"
 
 require "date"
 require "json"
-require "rexml/document"
-require "rexml/xmldecl"
-require "rexml/cdata"
 
 require "development_tools"
 require "formula"
@@ -22,7 +19,6 @@ module Homebrew
     module_function
 
     GIT = "/usr/bin/git"
-    CURL = "/usr/bin/curl"
 
     BYTES_IN_1_MEGABYTE = 1024*1024
     MAX_STEP_OUTPUT_SIZE = BYTES_IN_1_MEGABYTE - (200*1024) # margin of safety
@@ -36,21 +32,9 @@ module Homebrew
 
       return Tap.fetch(tap) if HOMEBREW_TAP_REGEX.match?(tap)
 
-      if ENV["UPSTREAM_BOT_PARAMS"]
-        bot_argv = ENV["UPSTREAM_BOT_PARAMS"].split(" ")
-        bot_argv.extend HomebrewArgvExtension
-        if (tap = bot_argv.value("tap"))
-          return Tap.fetch(tap)
-        end
-      end
-
-      # Get tap from Jenkins UPSTREAM_GIT_URL, GIT_URL or
-      # GitHub Actions GITHUB_REPOSITORY
-      git_url =
-        ENV["UPSTREAM_GIT_URL"] ||
-        ENV["GIT_URL"] ||
-        ENV["GITHUB_REPOSITORY"]
-      return unless git_url
+      # Get tap from GitHub Actions GITHUB_REPOSITORY
+      git_url = ENV["GITHUB_REPOSITORY"]
+      return if git_url.blank?
 
       url_path = git_url.sub(%r{^https?://.*github\.com/}, "")
                         .chomp("/")
@@ -61,252 +45,6 @@ module Homebrew
         # Don't care if tap fetch fails
         nil
       end
-    end
-
-    def copy_bottles_from_jenkins
-      jenkins = ENV["JENKINS_HOME"]
-      job = ENV["UPSTREAM_JOB_NAME"]
-      id = ENV["UPSTREAM_BUILD_ID"]
-      raise "Missing Jenkins variables!" unless (job && id) || Homebrew.args.dry_run?
-
-      jenkins_dir  = "#{jenkins}/jobs/#{job}/configurations/axis-version/*/"
-      jenkins_dir += "builds/#{id}/archive/*.bottle*.*"
-      bottles = Dir[jenkins_dir]
-
-      raise "No bottles found in #{jenkins_dir}!" if bottles.empty? && !Homebrew.args.dry_run?
-
-      FileUtils.cp bottles, Dir.pwd, verbose: true
-    end
-
-    def test_ci_upload(tap)
-      # Don't trust formulae we're uploading
-      ENV["HOMEBREW_DISABLE_LOAD_FORMULA"] = "1"
-
-      bintray_user = ENV["HOMEBREW_BINTRAY_USER"]
-      bintray_key = ENV["HOMEBREW_BINTRAY_KEY"]
-      if !bintray_user || !bintray_key
-        raise "Missing HOMEBREW_BINTRAY_USER or HOMEBREW_BINTRAY_KEY variables!" unless Homebrew.args.dry_run?
-      end
-
-      # Ensure that uploading Homebrew bottles on Linux doesn't use Linuxbrew.
-      bintray_org = Homebrew.args.bintray_org || "homebrew"
-      ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if bintray_org == "homebrew" && !OS.mac?
-
-      # Don't pass keys/cookies to subprocesses
-      ENV.clear_sensitive_environment!
-
-      copy_bottles_from_jenkins unless ENV["JENKINS_HOME"].nil?
-
-      raise "No bottles found in #{Dir.pwd}!" if Dir["*.bottle*.*"].empty? && !Homebrew.args.dry_run?
-
-      json_files = Dir.glob("*.bottle.json")
-      bottles_hash = json_files.reduce({}) do |hash, json_file|
-        hash.deep_merge(JSON.parse(IO.read(json_file)))
-      end
-
-      if Homebrew.args.dry_run?
-        bottles_hash = {
-          "testbottest" => {
-            "formula" => {
-              "pkg_version" => "1.0.0",
-            },
-            "bottle"  => {
-              "rebuild" => 0,
-              "tags"    => {
-                Utils::Bottles.tag => {
-                  "filename" =>
-                                "testbottest-1.0.0.#{Utils::Bottles.tag}.bottle.tar.gz",
-                  "sha256"   =>
-                                "20cdde424f5fe6d4fdb6a24cff41d2f7aefcd1ef2f98d46f6c074c36a1eef81e",
-                },
-              },
-            },
-            "bintray" => {
-              "package"    => "testbottest",
-              "repository" => "bottles",
-            },
-          },
-        }
-      end
-
-      first_formula_name = bottles_hash.keys.first
-      tap_name = first_formula_name.rpartition("/").first.chuzzle
-      tap_name ||= CoreTap.instance.name
-      tap ||= Tap.fetch(tap_name)
-
-      ENV["GIT_WORK_TREE"] = tap.path
-      ENV["GIT_DIR"] = "#{ENV["GIT_WORK_TREE"]}/.git"
-
-      # This variable is for Jenkins.
-      if (pr = ENV["UPSTREAM_PULL_REQUEST"])
-        if Homebrew.args.dry_run?
-          puts <<~EOS
-            #{GIT} am --abort
-            #{GIT} rebase --abort
-            #{GIT} checkout -f master
-            #{GIT} reset --hard origin/master
-            brew update
-          EOS
-        else
-          quiet_system GIT, "am", "--abort"
-          quiet_system GIT, "rebase", "--abort"
-          safe_system GIT, "checkout", "-f", "master"
-          safe_system GIT, "reset", "--hard", "origin/master"
-          safe_system "brew", "update"
-        end
-        pull_pr = "#{tap.default_remote}/pull/#{pr}"
-        safe_system "brew", "pull", "--clean", pull_pr
-      end
-
-      if ENV["UPSTREAM_BOTTLE_KEEP_OLD"] ||
-         ENV["BOT_PARAMS"].to_s.include?("--keep-old") ||
-         Homebrew.args.keep_old?
-        system "brew", "bottle", "--merge", "--write", "--keep-old", *json_files
-      elsif !Homebrew.args.dry_run?
-        system "brew", "bottle", "--merge", "--write", *json_files
-      else
-        puts "brew bottle --merge --write $JSON_FILES"
-      end
-
-      # This variable is for Jenkins.
-      upstream_number = ENV["UPSTREAM_BUILD_NUMBER"]
-      git_name = ENV["HOMEBREW_GIT_NAME"]
-      remote = "git@github.com:#{git_name}/homebrew-#{tap.repo}.git"
-      git_tag = if pr
-        "pr-#{pr}"
-      elsif upstream_number
-        "testing-#{upstream_number}"
-      elsif (number = ENV["BUILD_NUMBER"])
-        "other-#{number}"
-      elsif Homebrew.args.dry_run?
-        "$GIT_TAG"
-      end
-
-      if git_tag
-        if Homebrew.args.dry_run?
-          puts "#{GIT} push --force #{remote} origin/master:master :refs/tags/#{git_tag}"
-        else
-          safe_system GIT, "push", "--force", remote, "origin/master:master",
-                                                      ":refs/tags/#{git_tag}"
-        end
-      end
-
-      formula_packaged = {}
-
-      bottles_hash.each do |formula_name, bottle_hash|
-        version = bottle_hash["formula"]["pkg_version"]
-        bintray_package = bottle_hash["bintray"]["package"]
-        bintray_repo = bottle_hash["bintray"]["repository"]
-        bintray_packages_url =
-          "https://api.bintray.com/packages/#{bintray_org}/#{bintray_repo}"
-
-        rebuild = bottle_hash["bottle"]["rebuild"]
-
-        bottle_hash["bottle"]["tags"].each do |tag, _tag_hash|
-          filename = Bottle::Filename.new(formula_name, version, tag, rebuild)
-          bintray_url =
-            "#{Homebrew::EnvConfig.bottle_domain}/#{bintray_repo}/#{filename.bintray}"
-          filename_already_published = if Homebrew.args.dry_run?
-            puts "#{CURL} -I --output /dev/null #{bintray_url}"
-            false
-          else
-            begin
-              system CURL, *curl_args("-I", "--output", "/dev/null",
-                                      bintray_url)
-            end
-          end
-
-          if filename_already_published
-            raise <<~EOS
-              #{filename.bintray} is already published. Please remove it manually from
-              https://bintray.com/#{bintray_org}/#{bintray_repo}/#{bintray_package}/view#files
-            EOS
-          end
-
-          unless formula_packaged[formula_name]
-            package_url = "#{bintray_packages_url}/#{bintray_package}"
-            package_exists = if Homebrew.args.dry_run?
-              puts "#{CURL} --output /dev/null #{package_url}"
-              false
-            else
-              system CURL, *curl_args("--output", "/dev/null", package_url)
-            end
-
-            unless package_exists
-              package_blob = <<~EOS
-                {"name": "#{bintray_package}",
-                "public_download_numbers": true,
-                "public_stats": true}
-              EOS
-              if Homebrew.args.dry_run?
-                puts <<~EOS
-                  #{CURL} --user $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY
-                      --header Content-Type: application/json
-                      --data #{package_blob.delete("\n")}
-                      #{bintray_packages_url}
-                EOS
-              else
-                system_curl "--user", "#{bintray_user}:#{bintray_key}",
-                            "--header", "Content-Type: application/json",
-                            "--data", package_blob, bintray_packages_url,
-                            secrets: [bintray_key]
-                puts
-              end
-            end
-            formula_packaged[formula_name] = true
-          end
-
-          content_url = "https://api.bintray.com/content/#{bintray_org}"
-          content_url +=
-            "/#{bintray_repo}/#{bintray_package}/#{version}/#{filename.bintray}"
-          if Homebrew.args.dry_run?
-            puts <<~EOS
-              #{CURL} --user $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY
-                  --upload-file #{filename}
-                  #{content_url}
-            EOS
-          else
-            system_curl "--user", "#{bintray_user}:#{bintray_key}",
-                        "--upload-file", filename, content_url,
-                        secrets: [bintray_key]
-            puts
-          end
-        end
-
-        next unless Homebrew.args.publish?
-
-        publish_url = "https://api.bintray.com/content/#{bintray_org}"
-        publish_url += "/#{bintray_repo}/#{bintray_package}/#{version}/publish"
-
-        if Homebrew.args.dry_run?
-          puts <<~EOS
-            #{CURL} --user $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY --request POST
-                #{publish_url}
-          EOS
-        else
-          system_curl "--user", "#{bintray_user}:#{bintray_key}",
-                      publish_url, "--request", "POST",
-                      secrets: [bintray_key]
-        end
-      end
-
-      return unless git_tag
-
-      if Homebrew.args.dry_run?
-        puts "#{GIT} tag --force #{git_tag}"
-        puts "#{GIT} push --force #{remote} origin/master:master refs/tags/#{git_tag}"
-      else
-        safe_system GIT, "tag", "--force", git_tag
-        safe_system GIT, "push", "--force", remote, "origin/master:master",
-                                                    "refs/tags/#{git_tag}"
-      end
-    end
-
-    def system_curl(*args, secrets: [], **options)
-      system_command! CURL,
-                      args:         curl_args(*args, **options),
-                      print_stdout: true,
-                      secrets:      secrets
     end
 
     def run!
@@ -329,8 +67,6 @@ module Homebrew
              "log", "-1", "--format=%h (%s)"
       ).strip
       puts "Homebrew/homebrew-test-bot #{test_bot_revision}"
-      puts "ARGV: #{ARGV.join(" ")}"
-      puts "Homebrew.args: #{Homebrew.args}"
 
       tap = resolve_test_tap
       # Tap repository if required, this is done before everything else
@@ -348,8 +84,6 @@ module Homebrew
       ENV["HOMEBREW_GIT_NAME"] = Homebrew.args.git_name || "BrewTestBot"
       ENV["HOMEBREW_GIT_EMAIL"] = Homebrew.args.git_email ||
                                   "homebrew-test-bot@lists.sfconservancy.org"
-
-      return test_ci_upload(tap) if Homebrew.args.ci_upload?
 
       tests = []
       any_errors = false
@@ -386,48 +120,6 @@ module Homebrew
           any_errors ||= test_error
         end
       end
-
-      if Homebrew.args.junit?
-        xml_document = REXML::Document.new
-        xml_document << REXML::XMLDecl.new
-        testsuites = xml_document.add_element "testsuites"
-
-        tests.each do |test|
-          testsuite = testsuites.add_element "testsuite"
-          testsuite.add_attribute "name", "brew-test-bot.#{Utils::Bottles.tag}"
-          testsuite.add_attribute "tests", test.steps.count(&:passed?)
-          testsuite.add_attribute "failures", test.steps.count(&:failed?)
-          testsuite.add_attribute "timestamp", test.steps.first.start_time.iso8601
-
-          test.steps.each do |step|
-            testcase = testsuite.add_element "testcase"
-            testcase.add_attribute "name", step.command_short
-            testcase.add_attribute "status", step.status
-            testcase.add_attribute "time", step.time
-            testcase.add_attribute "timestamp", step.start_time.iso8601
-
-            next unless step.output?
-
-            output = sanitize_output_for_xml(step.output)
-            cdata = REXML::CData.new output
-
-            if step.passed?
-              elem = testcase.add_element "system-out"
-            else
-              elem = testcase.add_element "failure"
-              elem.add_attribute "message",
-                                "#{step.status}: #{step.command.join(" ")}"
-            end
-
-            elem << cdata
-          end
-        end
-
-        open("brew-test-bot.xml", "w") do |xml_file|
-          pretty_print_indent = 2
-          xml_document.write(xml_file, pretty_print_indent)
-        end
-      end
     ensure
       if HOMEBREW_CACHE.exist?
         if Homebrew.args.clean_cache?
@@ -440,24 +132,6 @@ module Homebrew
       end
 
       Homebrew.failed = any_errors
-    end
-
-    def sanitize_output_for_xml(output)
-      return output if output.empty?
-
-      # Remove invalid XML CData characters from step output.
-      invalid_xml_pat =
-        /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/
-      output.gsub!(invalid_xml_pat, "\uFFFD")
-
-      return output if output.bytesize <= MAX_STEP_OUTPUT_SIZE
-
-      # Truncate to 1MB to avoid hitting CI limits
-      output =
-        truncate_text_to_approximate_size(
-          output, MAX_STEP_OUTPUT_SIZE, front_weight: 0.0
-        )
-      "truncated output to 1MB:\n#{output}"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").sort.each do |file|
 end
 
 require "global"
+require "active_support/core_ext/object/blank"
 
 SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
 


### PR DESCRIPTION
Now that we've decommissioned jenkins.brew.sh we can delete all Jenkins related code. While doing this, audit remaining code to ensure that all methods, parameters, environment variables and configurations are those used and supported by Homebrew.