### PR TITLE
step: use output.empty?

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -73,7 +73,7 @@ module Homebrew
 
       output = result.merged_output
 
-      if output.present?
+      unless output.empty?
         output.force_encoding(Encoding::UTF_8)
 
         @output = if output.valid_encoding?


### PR DESCRIPTION
ActiveSupport can barf on some Unicode.