### PR TITLE
test_bot: restrict CLI arguments.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,5 +63,5 @@ jobs:
       if: matrix.os == 'macOS-latest'
       run: |
         brew test-bot --ci-upload --dry-run
-        brew test-bot https://github.com/Homebrew/brew/pull/4170 --dry-run
-        brew test-bot https://github.com/Homebrew/brew/commit/dc96e6f73551fbadd0c2169c3a79c47a936f71ae --dry-run
+        brew test-bot testbottest --dry-run
+        brew test-bot HEAD --dry-run

--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -7,7 +7,7 @@ module Homebrew
   def test_bot_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `test-bot` [<options>] <URL>|<formula>:
+        `test-bot` [<options>] [<formula>]:
 
         Test the full lifecycle of a formula change.
       EOS

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -279,24 +279,16 @@ module Homebrew
 
       test_bot_args.each do |argument|
         skip_cleanup_after = argument != test_bot_args.last
-        test_error = false
-        begin
-          current_test =
-            Test.new(argument, tap:                 tap,
-                               git:                 GIT,
-                               skip_setup:          skip_setup,
-                               skip_cleanup_before: skip_cleanup_before,
-                               skip_cleanup_after:  skip_cleanup_after)
-          skip_setup = true
-          skip_cleanup_before = true
-        rescue ArgumentError => e
-          test_error = true
-          ofail e.message
-        else
-          test_error = !current_test.run
-          tests << current_test
-        end
-        any_errors ||= test_error
+        current_test =
+          Test.new(argument, tap:                 tap,
+                             git:                 GIT,
+                             skip_setup:          skip_setup,
+                             skip_cleanup_before: skip_cleanup_before,
+                             skip_cleanup_after:  skip_cleanup_after)
+        skip_setup = true
+        skip_cleanup_before = true
+        tests << current_test
+        any_errors ||= !current_test.run
       end
 
       failed_steps = tests.map { |test| test.steps.select(&:failed?) }


### PR DESCRIPTION
Accept only formula, `HEAD` or GitHub Actions commits for building.

I believe other functionality is unused. If I'm wrong: correct me.