### PR TITLE
Make GitHub Actions output less verbose

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -64,7 +64,7 @@ module Homebrew
   def setup_argv_and_env
     github_actions = ENV["GITHUB_ACTIONS"].present?
     if github_actions
-      ARGV << "--verbose" << "--cleanup"
+      ARGV << "--cleanup"
       ENV["HOMEBREW_COLOR"] = "1"
       ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
     end

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -246,7 +246,7 @@ module Homebrew
         GIT, "-C", Tap.fetch("homebrew/test-bot").path.to_s,
              "log", "-1", "--format=%h (%s)"
       ).strip
-      puts "Homebrew/homebrew-test-bot #{test_bot_revision}"
+      puts Formatter.headline("Using Homebrew/homebrew-test-bot #{test_bot_revision}", color: :cyan)
 
       tap = resolve_test_tap
       # Tap repository if required, this is done before everything else

--- a/spec/homebrew/step_spec.rb
+++ b/spec/homebrew/step_spec.rb
@@ -9,12 +9,13 @@ describe Homebrew::Step do
 
   let(:command) { ["brew", "config"] }
   let(:env) { {} }
-  let(:step) { described_class.new(command, env: env) }
+  let(:verbose) { false }
+  let(:step) { described_class.new(command, env: env, verbose: verbose) }
 
   describe "#run" do
     it "runs the command" do
       expect(step).to receive(:system_command)
-        .with("brew", args: ["config"], env: env, print_stderr: nil, print_stdout: nil)
+        .with("brew", args: ["config"], env: env, print_stderr: verbose, print_stdout: verbose)
         .and_return(OpenStruct.new(success?: true, merged_output: ""))
       step.run
     end

--- a/spec/stub/utils.rb
+++ b/spec/stub/utils.rb
@@ -6,9 +6,6 @@ def system_command(*)
     merged_output: "",
   )
 end
-
-def oh1(*) end
-
 module Formatter
   module_function
 


### PR DESCRIPTION
- Don't pass `--verbose` by default with GitHub Actions (instead, just output failed steps)
- Always output `brew config` even when it doesn't fail (as it almost never does).
- Don't run `brew --env` as we don't really care about the output.
- Output repository revisions with a headline and after they won't change again.
- More consistent spacing and colours.
