### PR TITLE
Provide arguments to only test one step.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,5 +69,6 @@ jobs:
       if: matrix.os == 'macOS-latest'
       run: |
         brew test-bot --ci-upload --dry-run
+        brew test-bot --only-setup --dry-run
         brew test-bot testbottest --dry-run
         brew test-bot HEAD --dry-run

--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -47,6 +47,18 @@ module Homebrew
              description: "publish the uploaded bottles."
       switch "--skip-recursive-dependents",
              description: "only test the direct dependents."
+      switch "--only-cleanup-before",
+             description: "Only run the pre-cleanup step. Needs `--cleanup`."
+      switch "--only-setup",
+             description: "Only run the local system setup check step."
+      switch "--only-tap-syntax",
+             description: "Only run the tap syntax check step."
+      switch "--only-formulae",
+             description: "Only run the formulae steps."
+      switch "--only-cleanup-after",
+             description: "Only run the post-cleanup step. Needs `--cleanup`."
+      conflicts "--only-cleanup-before", "--only-setup", "--only-tap-syntax",
+                "--only-formulae", "--only-cleanup-after"
     end
   end
 

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -980,13 +980,20 @@ module Homebrew
     end
 
     def run
-      cleanup_before
+      any_only = Homebrew.args.only_cleanup_before? ||
+                 Homebrew.args.only_setup? ||
+                 Homebrew.args.only_tap_syntax? ||
+                 Homebrew.args.only_formulae? ||
+                 Homebrew.args.only_cleanup_after?
+      no_only = !any_only
+
+      cleanup_before if no_only || Homebrew.args.only_cleanup_before?
       begin
-        setup
-        tap_syntax
-        test_formulae
+        setup if no_only || Homebrew.args.only_setup?
+        tap_syntax if no_only || Homebrew.args.only_tap_syntax?
+        test_formulae if no_only || Homebrew.args.only_formulae?
       ensure
-        cleanup_after
+        cleanup_after if no_only || Homebrew.args.only_cleanup_after?
       end
       all_steps_passed?
     end


### PR DESCRIPTION
This will allow the test-bot logs to be more segmented in GitHub Actions and avoid wasting time testing some formulae when others have invalid syntax.