### PR TITLE
Build multiple Test objects.

### DIFF
--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -20,15 +20,15 @@ module Homebrew
 
       test_bot_args.each do |argument|
         skip_cleanup_after = argument != test_bot_args.last
-        current_test = build_test(argument, tap:                 tap,
-                                            git:                 git,
-                                            skip_setup:          skip_setup,
-                                            skip_cleanup_before: skip_cleanup_before,
-                                            skip_cleanup_after:  skip_cleanup_after)
+        current_tests = build_tests(argument, tap:                 tap,
+                                              git:                 git,
+                                              skip_setup:          skip_setup,
+                                              skip_cleanup_before: skip_cleanup_before,
+                                              skip_cleanup_after:  skip_cleanup_after)
         skip_setup = true
         skip_cleanup_before = true
-        tests << current_test
-        any_errors ||= !run_test(current_test)
+        tests += current_tests.values
+        any_errors ||= !run_tests(current_tests)
       end
 
       failed_steps = tests.map { |test| test.steps.select(&:failed?) }
@@ -59,26 +59,28 @@ module Homebrew
       !any_only
     end
 
-    def build_test(argument, tap:, git:, skip_setup:, skip_cleanup_before:, skip_cleanup_after:)
-      # TODO: clean this up when all classes ported.
-      klass = if no_only_args? || Homebrew.args.only_tap_syntax?
-        Tests::TapSyntax
-      else
-        Test
-      end
+    def build_tests(argument, tap:, git:, skip_setup:, skip_cleanup_before:, skip_cleanup_after:)
+      tests = {
+        test: Test.new(argument, tap:                 tap,
+                                 git:                 git,
+                                 skip_setup:          skip_setup,
+                                 skip_cleanup_before: skip_cleanup_before,
+                                 skip_cleanup_after:  skip_cleanup_after),
+      }
 
-      klass.new(argument, tap:                 tap,
-                          git:                 git,
-                          skip_setup:          skip_setup,
-                          skip_cleanup_before: skip_cleanup_before,
-                          skip_cleanup_after:  skip_cleanup_after)
+      # TODO: clean this up when all classes ported.
+      tests[:tap_syntax] = Tests::TapSyntax.new(tap) if no_only_args? || Homebrew.args.only_tap_syntax?
+
+      tests
     end
 
-    def run_test(test)
+    def run_tests(tests)
+      test = tests[:test]
+
       test.cleanup_before if no_only_args? || Homebrew.args.only_cleanup_before?
       begin
         test.setup if no_only_args? || Homebrew.args.only_setup?
-        test.tap_syntax if no_only_args? || Homebrew.args.only_tap_syntax?
+        tests[:tap_syntax].tap_syntax if no_only_args? || Homebrew.args.only_tap_syntax?
         test.test_formulae if no_only_args? || Homebrew.args.only_formulae?
       ensure
         test.cleanup_after if no_only_args? || Homebrew.args.only_cleanup_after?

--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -3,6 +3,13 @@
 module Homebrew
   module Tests
     class TapSyntax < Test
+      def initialize(tap)
+        @tap = tap
+
+        # TODO: refactor into Test initializer exclusively
+        @steps = []
+      end
+
       # TODO: rename this when all classes ported.
       def tap_syntax
         return unless @tap


### PR DESCRIPTION
This will allow the creation of more Test subclasses that don't share methods and are correctly invoked by TestRunner.