### PR TITLE
formulae: make rev-parse only return revisions.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -42,7 +42,7 @@ module Homebrew
       end
 
       def rev_parse(ref)
-        Utils.popen_read(git, "-C", repository, "rev-parse", ref).strip
+        Utils.popen_read(git, "-C", repository, "rev-parse", "--verify", ref).strip
       end
 
       def current_sha1


### PR DESCRIPTION
Otherwise it can return e.g. `origin/master` if it cannot find it.