### PR TITLE
tests/formulae: add erlang to BFS whitelist

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -324,6 +324,7 @@ module Homebrew
         build_dependents_from_source_whitelist = %w[
           cabal-install
           docbook-xsl
+          erlang
           ghc
           go
           ocaml


### PR DESCRIPTION
This PR adds erlang to build-from-source whitelist. This should help to catch build problems on erlang-dependant formulae earlier and help to decide if we need to add a versioned formula for the previous version (in case of major updates).