### PR TITLE
test_bot: automatically detect linuxbrew-core.

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -37,6 +37,9 @@ module Homebrew
       url_path = git_url.sub(%r{^https?://.*github\.com/}, "")
                         .chomp("/")
                         .sub(/\.git$/, "")
+
+      return CoreTap.instance if url_path == CoreTap.instance.full_name
+
       begin
         Tap.fetch(url_path) if url_path.match?(HOMEBREW_TAP_REGEX)
       rescue


### PR DESCRIPTION
This avoids having to specify `--tap`.