### PR TITLE
lib/tests/formulae.rb:408: Use `any_version_installed?` instead of `installed?`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -405,7 +405,7 @@ module Homebrew
         formula_recursive_dependencies.each do |dependency|
           conflicts += dependency.to_formula.conflicts.map do |c|
             Formulary.factory(c.name)
-          end.select(&:installed?)
+          end.select(&:any_version_installed?)
         end
         conflicts.each do |conflict|
           test "brew", "unlink", conflict.name


### PR DESCRIPTION
Error message encountered:

> ==> brew fetch --retry freerdp
Error: Calling Formula#installed? is deprecated! Use Formula#latest_version_installed? (or Formula#any_version_installed? ) instead.
Please report this issue to the homebrew/test-bot tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/tests/formulae.rb:408

Source:
https://github.com/Linuxbrew/homebrew-xorg/pull/645/checks?check_run_id=702425713#step:6:39

I believe `any_version_installed?` is more appropriate than `latest_version_installed?`.