### PR TITLE
lib/tests/formulae.rb:395: Use any_version_installed? instead of installed?

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -392,7 +392,7 @@ module Homebrew
         return if formula.linked_keg.exist?
 
         conflicts = formula.conflicts.map { |c| Formulary.factory(c.name) }
-                           .select(&:installed?)
+                           .select(&:any_version_installed?)
         formula_recursive_dependencies = begin
           formula.recursive_dependencies
         rescue TapFormulaUnavailableError => e


### PR DESCRIPTION
Same as #410 but for line 395

Failed log: 
https://github.com/Linuxbrew/homebrew-xorg/pull/645/checks?check_run_id=702574635#step:6:73