### PR TITLE
README: move documentation to --help.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # Homebrew Test Bot
 
-Tests the full lifecycle of a Homebrew change.
+Tests the full lifecycle of a Homebrew change to a tap (Git repository).
 
-## Installation
+## Install
 
-```bash
-brew tap homebrew/test-bot
-```
+`brew test-bot` is automatically installed when first run.
 
-## CI Providers
+## Usage
 
-`test-bot` only supports GitHub Actions as a CI provider. This is because Homebrew uses GitHub Actions and it's freely available for public and private use with macOS and Linux workers.
+See `brew test-bot --help` or [the `brew man` output](https://docs.brew.sh/Manpage).
+
+## Tests
+
+Tests can be run with `bundle install && bundle exec rspec`.
+
+## Copyright
+
+Copyright (c) Homebrew maintainers. See [LICENSE.txt](https://github.com/Homebrew/homebrew-test-bot/blob/master/LICENSE.txt) for details.

--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -9,7 +9,9 @@ module Homebrew
       usage_banner <<~EOS
         `test-bot` [<options>] [<formula>]:
 
-        Test the full lifecycle of a formula change.
+        Tests the full lifecycle of a Homebrew change to a tap (Git repository). For example, for a GitHub Actions pull request that changes a formula `brew test-bot` will ensure the system is cleaned and setup to test the formula, install the formula, run various tests and checks on it, bottle (package) the binaries and test formulae that depend on it to ensure they aren't broken by these changes.
+
+        Only supports GitHub Actions as a CI provider. This is because Homebrew uses GitHub Actions and it's freely available for public and private use with macOS and Linux workers.
       EOS
 
       switch "--dry-run",


### PR DESCRIPTION
This is included in `brew man`, `brew test-bot --help` and is less likely to get outdated as a result.