### PR TITLE
Check for untapped deps of dependents

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -346,7 +346,15 @@ module Homebrew
           if Homebrew.args.skip_recursive_dependents?
             f.deps
           else
-            f.recursive_dependencies
+            begin
+              f.recursive_dependencies
+            rescue TapFormulaUnavailableError => e
+              raise if e.tap.installed?
+
+              e.tap.clear_cache
+              safe_system "brew", "tap", e.tap.name
+              retry
+            end
           end.reject(&:optional?)
         end)
 


### PR DESCRIPTION
Similar to #117, rescue from TapFormulaUnavailableError while checking the recursive dependencies of formula dependents.

This popped up because the osrf/simulation tap that I maintain has an old but LTS formula (`gazebo7`) that [depends on `cartr/qt4/qt@4`](https://github.com/osrf/homebrew-simulation/blob/master/Formula/gazebo7.rb#L14), and when I try to build one of its dependencies hosted in that tap (`ogre1.9`), `test-bot` [fails with](https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/867/label=osx_mojave/console):

~~~
Error: No available formula with the name "cartr/qt4/qt@4" 
Please tap it and then try again: brew tap cartr/qt4
~~~

I traced it to `lib/tests/formulae.rb:349` in local testing with `--debug` and `--verbose`. Rescuing from `TapFormulaUnavailableError` causes `cartr/qt4` to be tapped and the `test-bot` run continues.