### PR TITLE
Refer to default branch in links with HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Tests can be run with `bundle install && bundle exec rspec`.
 
 ## Copyright
 
-Copyright (c) Homebrew maintainers. See [LICENSE.txt](https://github.com/Homebrew/homebrew-test-bot/blob/master/LICENSE.txt) for details.
+Copyright (c) Homebrew maintainers. See [LICENSE.txt](https://github.com/Homebrew/homebrew-test-bot/blob/HEAD/LICENSE.txt) for details.


### PR DESCRIPTION
Anywhere we can use `blob/master` we can use `blob/HEAD` instead. This will make life easier if we ever rename our default branch in future (once/if Git and GitHub provides the necessary tooling to do so).