### PR TITLE
lib/tests/setup: install bundler gems.

### DIFF
--- a/lib/tests/setup.rb
+++ b/lib/tests/setup.rb
@@ -6,6 +6,8 @@ module Homebrew
       def run!
         test_header(:Setup)
 
+        test "brew", "install-bundler-gems"
+
         # Always output `brew config` output even when it doesn't fail.
         test "brew", "config", verbose: true
 


### PR DESCRIPTION
This should avoid `brew doctor` failures due to not-yet installed gems on self-hosted runners.