### PR TITLE
Move `brew cleanup` to `cleanup_shared`.

### DIFF
--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -90,6 +90,8 @@ module Homebrew
         reset_if_needed(git_repo)
         prune_if_needed(git_repo)
       end
+
+      test "brew", "cleanup", "--prune=3"
     end
 
     private

--- a/lib/tests/cleanup_after.rb
+++ b/lib/tests/cleanup_after.rb
@@ -22,8 +22,6 @@ module Homebrew
 
         # Keep all "brew" invocations after cleanup_shared
         # (which cleans up Homebrew/brew)
-        test "brew", "cleanup", "--prune=3"
-
         if Homebrew.args.local?
           FileUtils.rm_rf ENV["HOMEBREW_HOME"]
           FileUtils.rm_rf ENV["HOMEBREW_LOGS"]


### PR DESCRIPTION
This means it'll be run both before and after builds.