### PR TITLE
Cleanup test_bot_tap logic.

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -8,7 +8,7 @@ module Homebrew
 
     protected
 
-    attr_reader :tap, :git, :steps, :repository, :test_bot_tap
+    attr_reader :tap, :git, :steps, :repository
 
     def initialize(tap: nil, git: nil)
       @tap = tap
@@ -17,7 +17,6 @@ module Homebrew
       @steps = []
 
       @repository = if @tap
-        @test_bot_tap = @tap.to_s == "homebrew/test-bot"
         @tap.path
       else
         CoreTap.instance.path

--- a/lib/tests/cleanup_after.rb
+++ b/lib/tests/cleanup_after.rb
@@ -11,11 +11,6 @@ module Homebrew
 
         test_header(:CleanupAfter)
 
-        unless test_bot_tap
-          clear_stash_if_needed(repository)
-          reset_if_needed(repository)
-        end
-
         pkill_if_needed
 
         cleanup_shared

--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -6,12 +6,6 @@ module Homebrew
       def run!
         test_header(:CleanupBefore)
 
-        unless test_bot_tap
-          clear_stash_if_needed(repository)
-          quiet_system git, "-C", repository, "am", "--abort"
-          quiet_system git, "-C", repository, "rebase", "--abort"
-        end
-
         if tap.to_s != CoreTap.instance.name
           core_path = CoreTap.instance.path
           if core_path.exist?

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -148,7 +148,7 @@ module Homebrew
 
         modified_formulae = []
 
-        if tap && !test_bot_tap
+        if tap
           formula_path = tap.formula_dir.to_s
           @added_formulae +=
             diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "A")
@@ -156,7 +156,9 @@ module Homebrew
             diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "M")
           @deleted_formulae +=
             diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "D")
-        elsif @formulae.empty? && Homebrew.args.test_default_formula?
+        end
+
+        if Homebrew.args.test_default_formula?
           # Build the default test formula.
           @test_default_formula = true
           modified_formulae << "testbottest"


### PR DESCRIPTION
We don't want special logic for this tap any more (and it's not reliable
with e.g. Docker). Also allow `testbottest` to be tested purely based
on the argument being passed rather than needing the right tap.