### PR TITLE
formulae: test dependents where formula has missing test.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -615,6 +615,8 @@ module Homebrew
             test "brew", "test", "--verbose", formula_name
 
             steps.last.passed?
+          else
+            true
           end
 
           # Don't test dependents if the formula test failed.


### PR DESCRIPTION
This was implied by the variable name but omitted by mistake.