### PR TITLE
Don't test dependents on audit/linkage/test failure.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         if which brew &>/dev/null; then
           HOMEBREW_PREFIX="$(brew --prefix)"
           HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX/Homebrew"
-          brew update-reset "$HOMEBREW_REPOSITORY"
+          brew update-reset "$HOMEBREW_REPOSITORY" "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core"
           ln -s "$PWD" "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-test-bot"
         else
           HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
@@ -44,7 +44,10 @@ jobs:
         GEMS_HASH=$(shasum -a 256 "$HOMEBREW_REPOSITORY/Library/Homebrew/Gemfile.lock" | cut -f1 -d' ')
         echo "::set-output name=gems-hash::$GEMS_HASH"
 
-        if [ "$RUNNER_OS" = "Linux" ]; then
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          # don't care about `brew audit` here.
+          brew untap mongodb/brew
+        else
           sudo chown -R "$USER" "$HOMEBREW_PREFIX"
         fi
 

--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -10,6 +10,7 @@ module Homebrew
         broken_xcode_rubygems = MacOS.version == :mojave &&
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
         test "brew", "style", tap.name, args: args unless broken_xcode_rubygems
+        test "brew", "audit", "--skip-style", args: args
       end
     end
   end


### PR DESCRIPTION
We need to get on top of our failing CI problems. This will block us doing dependent testing or shipping bottles for formulae where linkage or tests fail on the changed formula. We will still allow this on dependent formulae.

Also, run `brew audit` without Git, style (RuboCop) or online checks in the tap syntax checking step. This is fast enough now (takes under a minute on my machine) and these are the audit failures we should never accept failures on.

Needs https://github.com/Homebrew/homebrew-core/pull/58905

CC @homebrew/core for thoughts