### PR TITLE
Refactor dry run & fail fast handling

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -10,9 +10,12 @@ module Homebrew
 
     attr_reader :tap, :git, :steps, :repository
 
-    def initialize(tap: nil, git: nil)
+    def initialize(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
       @tap = tap
       @git = git
+      @dry_run = dry_run
+      @fail_fast = fail_fast
+      @verbose = verbose
 
       @steps = []
 
@@ -32,9 +35,9 @@ module Homebrew
       puts Formatter.headline("Running #{klass}##{method}", color: :magenta)
     end
 
-    def test(*arguments, env: {}, args:, verbose: args.verbose?)
+    def test(*arguments, env: {}, verbose: @verbose)
       step = Step.new(arguments, env: env, verbose: verbose)
-      step.run(dry_run: args.dry_run?, fail_fast: args.fail_fast?)
+      step.run(dry_run: @dry_run, fail_fast: @fail_fast)
       @steps << step
       step
     end

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -69,19 +69,42 @@ module Homebrew
 
       no_only_args = no_only_args?(args)
 
-      tests[:setup] = Tests::Setup.new if !skip_setup && (no_only_args || args.only_setup?)
+      if !skip_setup && (no_only_args || args.only_setup?)
+        tests[:setup] = Tests::Setup.new(dry_run:   args.dry_run?,
+                                         fail_fast: args.fail_fast?,
+                                         verbose:   args.verbose?)
+      end
 
-      tests[:tap_syntax] = Tests::TapSyntax.new(tap: tap || CoreTap.instance) if no_only_args || args.only_tap_syntax?
+      if no_only_args || args.only_tap_syntax?
+        tests[:tap_syntax] = Tests::TapSyntax.new(tap:       tap || CoreTap.instance,
+                                                  dry_run:   args.dry_run?,
+                                                  fail_fast: args.fail_fast?,
+                                                  verbose:   args.verbose?)
+      end
 
-      tests[:formulae] = Tests::Formulae.new(argument, tap: tap, git: git) if no_only_args || args.only_formulae?
+      if no_only_args || args.only_formulae?
+        tests[:formulae] = Tests::Formulae.new(argument, tap:       tap,
+                                                         git:       git,
+                                                         dry_run:   args.dry_run?,
+                                                         fail_fast: args.fail_fast?,
+                                                         verbose:   args.verbose?)
+      end
 
       if args.cleanup?
         if !skip_cleanup_before && (no_only_args || args.only_cleanup_before?)
-          tests[:cleanup_before] = Tests::CleanupBefore.new(tap: tap, git: git)
+          tests[:cleanup_before] = Tests::CleanupBefore.new(tap:       tap,
+                                                            git:       git,
+                                                            dry_run:   args.dry_run?,
+                                                            fail_fast: args.fail_fast?,
+                                                            verbose:   args.verbose?)
         end
 
-        if !skip_cleanup_after &&  (no_only_args || args.only_cleanup_after?)
-          tests[:cleanup_after]  = Tests::CleanupAfter.new(tap: tap, git: git)
+        if !skip_cleanup_after && (no_only_args || args.only_cleanup_after?)
+          tests[:cleanup_after] = Tests::CleanupAfter.new(tap:       tap,
+                                                          git:       git,
+                                                          dry_run:   args.dry_run?,
+                                                          fail_fast: args.fail_fast?,
+                                                          verbose:   args.verbose?)
         end
       end
 

--- a/lib/tests/cleanup_after.rb
+++ b/lib/tests/cleanup_after.rb
@@ -11,9 +11,9 @@ module Homebrew
 
         test_header(:CleanupAfter)
 
-        pkill_if_needed(args: args)
+        pkill_if_needed
 
-        cleanup_shared(args: args)
+        cleanup_shared
 
         # Keep all "brew" invocations after cleanup_shared
         # (which cleans up Homebrew/brew)
@@ -25,13 +25,13 @@ module Homebrew
 
       private
 
-      def pkill_if_needed(args:)
+      def pkill_if_needed
         pgrep = ["pgrep", "-f", HOMEBREW_CELLAR.to_s]
         if quiet_system(*pgrep)
-          test "pkill", "-f", HOMEBREW_CELLAR.to_s, args: args
+          test "pkill", "-f", HOMEBREW_CELLAR.to_s
           if quiet_system(*pgrep)
             sleep 1
-            test "pkill", "-9", "-f", HOMEBREW_CELLAR.to_s, args: args if system(*pgrep)
+            test "pkill", "-9", "-f", HOMEBREW_CELLAR.to_s if system(*pgrep)
           end
         end
       end

--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -9,13 +9,12 @@ module Homebrew
         if tap.to_s != CoreTap.instance.name
           core_path = CoreTap.instance.path
           if core_path.exist?
-            test git, "-C", core_path.to_s, "fetch", "--depth=1", "origin", args: args
-            reset_if_needed(core_path.to_s, args: args)
+            test git, "-C", core_path.to_s, "fetch", "--depth=1", "origin"
+            reset_if_needed(core_path.to_s)
           else
             test git, "clone", "--depth=1",
                   CoreTap.instance.default_remote,
-                  core_path.to_s,
-                  args: args
+                  core_path.to_s
           end
         end
 
@@ -23,16 +22,16 @@ module Homebrew
 
         # Keep all "brew" invocations after cleanup_shared
         # (which cleans up Homebrew/brew)
-        cleanup_shared(args: args)
+        cleanup_shared
 
         installed_taps = Tap.select(&:installed?).map(&:name)
         (REQUIRED_TAPS - installed_taps).each do |tap|
-          test "brew", "tap", tap, args: args
+          test "brew", "tap", tap
         end
 
         # install newer Git when needed
         if OS.mac? && MacOS.version < :sierra
-          test "brew", "install", "git", args: args
+          test "brew", "install", "git"
           ENV["HOMEBREW_FORCE_BREWED_GIT"] = "1"
           change_git!("#{HOMEBREW_PREFIX}/opt/git/bin/git")
         end

--- a/lib/tests/setup.rb
+++ b/lib/tests/setup.rb
@@ -6,12 +6,12 @@ module Homebrew
       def run!(args:)
         test_header(:Setup)
 
-        test "brew", "install-bundler-gems", args: args
+        test "brew", "install-bundler-gems"
 
         # Always output `brew config` output even when it doesn't fail.
-        test "brew", "config", verbose: true, args: args
+        test "brew", "config", verbose: true
 
-        test "brew", "doctor", args: args
+        test "brew", "doctor"
       end
     end
   end

--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -6,11 +6,11 @@ module Homebrew
       def run!(args:)
         test_header(:TapSyntax)
 
-        test "brew", "readall", "--aliases", tap.name, args: args
+        test "brew", "readall", "--aliases", tap.name
         broken_xcode_rubygems = MacOS.version == :mojave &&
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
-        test "brew", "style", tap.name, args: args unless broken_xcode_rubygems
-        test "brew", "audit", "--skip-style", args: args
+        test "brew", "style", tap.name unless broken_xcode_rubygems
+        test "brew", "audit", "--skip-style"
       end
     end
   end


### PR DESCRIPTION
I personally found this call very confusing:

```rb
test "command", "arg1", "arg2", args: args
```

I've tried to refactor that away by instead passing the needed dry run and fail fast args to the Test class `initialize` method, store it there and reference that in the `test` method.