### PR TITLE
lib/tests/formulae: set permissions in cleanup_during!

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -669,6 +669,7 @@ module Homebrew
 
         test_header(:Formulae, method: :cleanup_during!)
 
+        FileUtils.chmod_R "u+rw", HOMEBREW_CACHE, force: true
         test "rm", "-rf", HOMEBREW_CACHE.to_s
       end
 


### PR DESCRIPTION
Otherwise, `rm -rf` will fail when deleting `go_mod_cache`.