### PR TITLE
More feedback on some slower non-test tasks

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -35,6 +35,10 @@ module Homebrew
       puts Formatter.headline("Running #{klass}##{method}", color: :magenta)
     end
 
+    def info_header(text)
+      puts Formatter.headline(text, color: :cyan)
+    end
+
     def test(*arguments, env: {}, verbose: @verbose)
       step = Step.new(arguments, env: env, verbose: verbose)
       step.run(dry_run: @dry_run, fail_fast: @fail_fast)

--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -34,6 +34,7 @@ module Homebrew
 
       paths_to_delete = []
 
+      info_header "Determining #{HOMEBREW_PREFIX} files to purge..."
       Keg::MUST_BE_WRITABLE_DIRECTORIES.each(&:mkpath)
       Pathname.glob("#{HOMEBREW_PREFIX}/**/*", File::FNM_DOTMATCH).each do |path|
         next if Keg::MUST_BE_WRITABLE_DIRECTORIES.include?(path)
@@ -62,6 +63,7 @@ module Homebrew
       end
 
       # Do this in a second pass so that all children have their permissions fixed before we delete the parent.
+      info_header "Purging..."
       FileUtils.rm_rf paths_to_delete
 
       if tap

--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -46,7 +46,7 @@ module Homebrew
         ).strip
         puts
         verb = tap ? "Using" : "Testing"
-        puts Formatter.headline("#{verb} Homebrew/brew #{brew_version} (#{brew_commit_subject})", color: :cyan)
+        info_header "#{verb} Homebrew/brew #{brew_version} (#{brew_commit_subject})"
       end
     end
   end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -125,7 +125,7 @@ module Homebrew
             git, "-C", CoreTap.instance.path.to_s,
                   "log", "-1", "--format=%h (%s)"
           ).strip
-          puts Formatter.headline("Using #{CoreTap.instance.full_name} #{core_revision}", color: :cyan)
+          info_header "Using #{CoreTap.instance.full_name} #{core_revision}"
         end
 
         if tap
@@ -137,7 +137,7 @@ module Homebrew
             git, "-C", tap.path.to_s,
                   "log", "-1", "--format=%h (%s)"
           ).strip
-          puts Formatter.headline("Testing #{tap.full_name} #{tap_revision}:", color: :cyan)
+          info_header "Testing #{tap.full_name} #{tap_revision}:"
         end
 
         puts <<-EOS
@@ -170,7 +170,7 @@ module Homebrew
 
         return if @added_formulae.blank? && modified_formulae.blank? && @deleted_formulae.blank?
 
-        puts Formatter.headline("Testing Formula changes:", color: :cyan)
+        info_header "Testing Formula changes:"
         puts <<-EOS
     added    #{@added_formulae.blank? ? "(empty)" : @added_formulae.join(" ")}
     modified #{modified_formulae.blank? ? "(empty)" : modified_formulae.join(" ")}
@@ -256,6 +256,7 @@ module Homebrew
           test "brew", "unlink", name
         end
 
+        info_header "Determining dependencies..."
         installed = Utils.safe_popen_read("brew", "list").split("\n")
         dependencies =
           Utils.safe_popen_read("brew", "deps", "--include-build",
@@ -296,6 +297,8 @@ module Homebrew
           @testable_dependents = @bottled_dependents = @source_dependents = []
           return
         end
+
+        info_header "Determining dependents..."
 
         build_dependents_from_source_whitelist = %w[
           cabal-install
@@ -591,6 +594,8 @@ module Homebrew
         install_mercurial_if_needed(deps, reqs)
         install_subversion_if_needed(deps, reqs)
         setup_formulae_deps_instances(formula, formula_name, args: args)
+
+        info_header "Starting build of #{formula_name}"
 
         test "brew", "fetch", "--retry", *fetch_args
 


### PR DESCRIPTION
Things like purging the prefix isn't the quickest task in the world. But because it doesn't go through the `test` method, there's no indication that is what is currently happening - it just appears that it's still doing `git clean` or something.

For tasks like this, and depenency/dependent searching, it's worthwhile to print something that indicates what is happening.