### PR TITLE
Improve errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,10 +100,14 @@ jobs:
         cat steps_output.txt
         rm steps_output.txt
 
-    - name: Run brew test-bot --dry-run tests
+    - name: Run brew test-bot --ci-upload --dry-run
       if: matrix.os == 'macOS-latest'
-      run: |
-        brew test-bot --ci-upload --dry-run
-        brew test-bot --only-setup --dry-run
-        brew test-bot testbottest --dry-run
-        brew test-bot HEAD --dry-run
+      run: brew test-bot --ci-upload --dry-run
+
+    - name: Run brew test-bot --only-setup --dry-run
+      if: matrix.os == 'macOS-latest'
+      run: brew test-bot --only-setup --dry-run
+
+    - name: Run brew test-bot testbottest --dry-run
+      if: matrix.os == 'macOS-latest'
+      run: brew test-bot testbottest --dry-run

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -49,7 +49,7 @@ module Homebrew
       $stderr.sync = true
 
       if Pathname.pwd == HOMEBREW_PREFIX && args.cleanup?
-        odie "cannot use --cleanup from HOMEBREW_PREFIX as it will delete all output."
+        raise UsageError, "cannot use --cleanup from HOMEBREW_PREFIX as it will delete all output."
       end
 
       ENV["HOMEBREW_DEVELOPER"] = "1"

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -169,7 +169,7 @@ module Homebrew
 
         @formulae += @added_formulae + modified_formulae
 
-        return if @added_formulae.blank? && modified_formulae.blank? && @deleted_formulae.blank?
+        raise UsageError, "Did not find any formulae to test!" if @formulae.blank? && @deleted_formulae.blank?
 
         puts Formatter.headline("Testing Formula changes:", color: :cyan)
         puts <<-EOS


### PR DESCRIPTION
- Raise an exception if we haven't specified any formulae or found any to test (as that would be a no-op which almost always signals an error).
- use `UsageError`s rather than `odie` to get `--help` output