### PR TITLE
formulae: don't audit deprecated formulae

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -613,7 +613,7 @@ module Homebrew
               env:  { "HOMEBREW_DEVELOPER" => nil }
         install_passed = steps.last.passed?
 
-        test "brew", "audit", *audit_args
+        test "brew", "audit", *audit_args unless formula.deprecated?
         return unless install_passed
 
         bottle_reinstall_formula(formula, new_formula, args: args)


### PR DESCRIPTION
It might not be worth spending time resolving audit failures of deprecated formulae, so don't have `test-bot` audit them.

Motivated by https://github.com/Homebrew/homebrew-core/pull/59071.