### PR TITLE
formulae: loosen "no formulae" failure.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -168,7 +168,9 @@ module Homebrew
 
         @formulae += @added_formulae + modified_formulae
 
-        raise UsageError, "Did not find any formulae to test!" if @formulae.blank? && @deleted_formulae.blank?
+        if @formulae.blank? && @deleted_formulae.blank? && diff_start_sha1 == diff_end_sha1
+          raise UsageError, "Did not find any formulae or commits to test!"
+        end
 
         info_header "Testing Formula changes:"
         puts <<-EOS


### PR DESCRIPTION
Allow this to pass as long as the start/end SHAs are different (as this indicates that we've got these values correctly from GitHub Actions).

Fixing issue seen in https://github.com/Homebrew/homebrew-core/pull/59205/checks?check_run_id=953231796#step:5:30