### PR TITLE
Always output core and tap revisions.

### DIFF
--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -48,18 +48,6 @@ module Homebrew
           ENV["HOMEBREW_FORCE_BREWED_GIT"] = "1"
           change_git!("#{HOMEBREW_PREFIX}/opt/git/bin/git")
         end
-
-        brew_version = Utils.safe_popen_read(
-          git, "-C", HOMEBREW_REPOSITORY.to_s,
-                "describe", "--tags", "--abbrev", "--dirty"
-        ).strip
-        brew_commit_subject = Utils.safe_popen_read(
-          git, "-C", HOMEBREW_REPOSITORY.to_s,
-                "log", "-1", "--format=%s"
-        ).strip
-        puts
-        verb = tap ? "Using" : "Testing"
-        info_header "#{verb} Homebrew/brew #{brew_version} (#{brew_commit_subject})"
       end
     end
   end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -120,14 +120,6 @@ module Homebrew
 
         diff_start_sha1 = diff_end_sha1 if @formulae.present?
 
-        if tap.to_s != CoreTap.instance.name
-          core_revision = Utils.safe_popen_read(
-            git, "-C", CoreTap.instance.path.to_s,
-                  "log", "-1", "--format=%h (%s)"
-          ).strip
-          info_header "Using #{CoreTap.instance.full_name} #{core_revision}"
-        end
-
         if tap
           # Use popen_read as this is allowed to fail.
           tap_origin_master_revision = Utils.popen_read(
@@ -138,7 +130,6 @@ module Homebrew
             git, "-C", tap.path.to_s,
                   "log", "-1", "--format=%h (%s)"
           ).strip
-          info_header "Testing #{tap.full_name} #{tap_revision}:"
         end
 
         puts <<-EOS


### PR DESCRIPTION
This is useful when `test-bot` is run in multiple steps to ensure that these are always correct.