### PR TITLE
GitHub Actions cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: GitHub Actions CI
 on:
   push:
     branches: master
-  pull_request: []
+  pull_request:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
@@ -16,7 +16,7 @@ jobs:
 
     - name: Cache Homebrew Bundler RubyGems
       id: cache
-      uses: actions/cache@main
+      uses: actions/cache@v1
       with:
         path: ${{ steps.set-up-homebrew.outputs.gems-path }}
         key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -26,14 +26,11 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: brew install-bundler-gems
 
-    - name: Run brew test-bot --only-cleanup-before
-      run: brew test-bot --only-cleanup-before
+    - run: brew test-bot --only-cleanup-before
 
-    - name: Run brew test-bot --only-setup
-      run: brew test-bot --only-setup
+    - run: brew test-bot --only-setup
 
-    - name: Run brew test-bot --only-tap-syntax
-      run: brew test-bot --only-tap-syntax
+    - run: brew test-bot --only-tap-syntax
 
     - name: Set up Ruby
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
- Fix `pull_request: []` warning
- Use `cache@v1` to fix issues.
- Remove unnecessary implicit/duplicate `name`s.