### PR TITLE
formulae: set root_url to GitHub Releases url

### DIFF
--- a/lib/test_ci_upload.rb
+++ b/lib/test_ci_upload.rb
@@ -37,6 +37,14 @@ module Homebrew
         hash.deep_merge(JSON.parse(IO.read(json_file)))
       end
 
+      bottles_hash.each do |_, bottle_hash|
+        root_url = bottle_hash["bottle"]["root_url"]
+
+        next unless root_url.match HOMEBREW_RELEASES_URL_REGEX
+
+        odie "Refusing to upload to GitHub Releases, use `brew pr-upload`."
+      end
+
       if args.dry_run?
         bottles_hash = {
           "testbottest" => {

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -414,8 +414,14 @@ module Homebrew
           return
         end
 
-        ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if MacOS.version >= :catalina
         root_url = args.root_url
+
+        # GitHub Releases url
+        if !root_url && !tap.core_tap? && !args.bintray_org && !@test_default_formula
+          root_url = "#{tap.default_remote}/releases/download/#{formula.name}-#{formula.pkg_version}"
+        end
+
+        ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if MacOS.version >= :catalina
         bottle_args = ["--verbose", "--json", formula.full_name]
         bottle_args << "--keep-old" if args.keep_old? && !new_formula
         bottle_args << "--skip-relocation" if args.skip_relocation?


### PR DESCRIPTION
If not testing core tap (and a bunch of other conditions), set the root_url to GitHub releases url.
This url would later be used in `brew pr-upload` to determine what release to create.