### PR TITLE
formulae: test reverse-deps of linux-only formulae

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -291,7 +291,8 @@ module Homebrew
         build_dependencies = dependencies - runtime_or_test_dependencies
         @unchanged_build_dependencies = build_dependencies - @formulae
 
-        if args.keep_old?
+        # Test reverse dependencies for linux-only formulae in linuxbrew-core.
+        if args.keep_old? && !formula.requirements.include?(LinuxRequirement.new)
           @testable_dependents = @bottled_dependents = @source_dependents = []
           return
         end


### PR DESCRIPTION
Currently when bumping linux-only formulae in linuxbrew-core, reverse dependencies aren't tested because we `--keep-old`. This is undesired as formulae updates could cause breakage of the other formulae that depend on it.
This PR changes that. 