### PR TITLE
formulae: run livecheck only if formula is livecheckable

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -616,7 +616,7 @@ module Homebrew
              env:  { "HOMEBREW_DEVELOPER" => nil }
         install_passed = steps.last.passed?
 
-        test "brew", "livecheck", *livecheck_args unless formula.livecheck.skip?
+        test "brew", "livecheck", *livecheck_args if formula.livecheckable? && !formula.livecheck.skip?
 
         test "brew", "audit", *audit_args unless formula.deprecated?
         return unless install_passed


### PR DESCRIPTION
Homebrew/homebrew-core/pull/60943 is currently failing as `livecheck` has not been added for the formula