### PR TITLE
formulae: fix when tap is nil

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -417,8 +417,8 @@ module Homebrew
         root_url = args.root_url
 
         # GitHub Releases url
-        if !root_url && !tap.core_tap? && !args.bintray_org && !@test_default_formula
-          root_url = "#{tap.default_remote}/releases/download/#{formula.name}-#{formula.pkg_version}"
+        root_url ||= if tap.present? && !tap.core_tap? && !args.bintray_org && !@test_default_formula
+          "#{tap.default_remote}/releases/download/#{formula.name}-#{formula.pkg_version}"
         end
 
         ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if MacOS.version >= :catalina


### PR DESCRIPTION
Apparently `tap` can be undefined.

```
==> Running Formulae#formula!(testbottest)
==> Determining dependencies...
==> Determining dependents...
==> Starting build of testbottest
==> brew fetch --retry testbottest --build-bottle --force
==> brew install --only-dependencies --verbose --build-bottle testbottest
==> brew install --verbose --build-bottle testbottest
==> brew audit testbottest --online --git --skip-style
Error: undefined method `core_tap?' for nil:NilClass
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/tests/formulae.rb:420:in `bottle_reinstall_formula'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/tests/formulae.rb:630:in `formula!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/tests/formulae.rb:20:in `block in run!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/tests/formulae.rb:19:in `each'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/tests/formulae.rb:19:in `run!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/test_runner.rb:119:in `run_tests'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/test_runner.rb:36:in `block in run!'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/delegate.rb:83:in `each'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/delegate.rb:83:in `method_missing'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/test_runner.rb:25:in `run!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/test_bot.rb:125:in `run!'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-test-bot/cmd/test-bot.rb:75:in `test_bot'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```

https://github.com/Homebrew/brew/pull/8727/checks?check_run_id=1117391933#step:24:34