### PR TITLE
cleanup_before: don't use shallow clones/fetches.

### DIFF
--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -9,10 +9,10 @@ module Homebrew
         if tap.to_s != CoreTap.instance.name
           core_path = CoreTap.instance.path
           if core_path.exist?
-            test git, "-C", core_path.to_s, "fetch", "--depth=1", "origin"
+            test git, "-C", core_path.to_s, "fetch", "origin"
             reset_if_needed(core_path.to_s)
           else
-            test git, "clone", "--depth=1",
+            test git, "clone",
                  CoreTap.instance.default_remote,
                  core_path.to_s
           end


### PR DESCRIPTION
GitHub has requested we request our usage of shallow clones. As a result stop doing shallow clones or fetches of homebrew-core.