### PR TITLE
cleanup_before: don't fetch homebrew-core.

### DIFF
--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -9,7 +9,6 @@ module Homebrew
         if tap.to_s != CoreTap.instance.name
           core_path = CoreTap.instance.path
           if core_path.exist?
-            test git, "-C", core_path.to_s, "fetch", "origin"
             reset_if_needed(core_path.to_s)
           else
             test git, "clone",


### PR DESCRIPTION
The Homebrew/setup-homebrew GitHub Action does this for us (in a more reliable fashion).