### PR TITLE
Add --skip-dependents option

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -49,6 +49,8 @@ module Homebrew
              description: "publish the uploaded bottles."
       switch "--skip-recursive-dependents",
              description: "only test the direct dependents."
+      switch "--skip-dependents",
+             description: "do not test dependents."
       switch "--only-cleanup-before",
              description: "Only run the pre-cleanup step. Needs `--cleanup`."
       switch "--only-setup",

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -292,7 +292,8 @@ module Homebrew
         @unchanged_build_dependencies = build_dependencies - @formulae
 
         # Test reverse dependencies for linux-only formulae in linuxbrew-core.
-        if args.keep_old? && !formula.requirements.include?(LinuxRequirement.new)
+        # Skip testing of dependents if requested (e.g., for mass bottling)
+        if args.skip_dependents? || (args.keep_old? && !formula.requirements.include?(LinuxRequirement.new))
           @testable_dependents = @bottled_dependents = @source_dependents = []
           return
         end


### PR DESCRIPTION
In previous mass bottling workflows (Jenkins 👿 ), we would not systematically test dependents of a formula being bottled.

Doing so takes a lot of our time and CPU power, and some formulas would take days to test all dependents. Moreover, we do not gain much by this testing: most of those failures will be preexisting failures (which we will flag later on during bottling, anyway), or stuff where the Catalina bottle doesn’t work well on Big Sur (which we can’t actually fix anyway until we have bottled dependencies).

This adds a `--skip-dependents` option to restore this previous workflow.