### PR TITLE
brew bottle: Set HOMEBREW_NO_PATCHELF_RB_WRITE

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -429,7 +429,9 @@ module Homebrew
         bottle_args << "--force-core-tap" if @test_default_formula
         bottle_args << "--root-url=#{root_url}" if root_url
         bottle_args << "--or-later" if args.or_later?
-        test "brew", "bottle", *bottle_args
+        env = {}
+        env["HOMEBREW_NO_PATCHELF_RB_WRITE"] = "1" unless ENV["HOMEBREW_PATCHELF_RB_WRITE"].present?
+        test "brew", "bottle", *bottle_args, env: env
 
         bottle_step = steps.last
         return unless bottle_step.passed?

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -430,7 +430,7 @@ module Homebrew
         bottle_args << "--root-url=#{root_url}" if root_url
         bottle_args << "--or-later" if args.or_later?
         env = {}
-        env["HOMEBREW_NO_PATCHELF_RB_WRITE"] = "1" unless ENV["HOMEBREW_PATCHELF_RB_WRITE"].present?
+        env["HOMEBREW_NO_PATCHELF_RB_WRITE"] = "1" if ENV["HOMEBREW_PATCHELF_RB_WRITE"].blank?
         test "brew", "bottle", *bottle_args, env: env
 
         bottle_step = steps.last


### PR DESCRIPTION
Use Ruby patchelf to pour bottles, but not to build bottles. Set `HOMEBREW_NO_PATCHELF_RB_WRITE` unless `HOMEBREW_PATCHELF_RB_WRITE` is set.
