### PR TITLE
Don't untap `homebrew/cask-versions`.

### DIFF
--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -27,6 +27,7 @@ module Homebrew
     ALLOWED_TAPS = (REQUIRED_TAPS + %w[
       homebrew/bundle
       homebrew/cask
+      homebrew/cask-versions
       homebrew/services
     ]).freeze
 


### PR DESCRIPTION
Should speed up `Homebrew/brew` tests a little.