### PR TITLE
Exclude casks when determining dependants

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -312,10 +312,10 @@ module Homebrew
           rust
         ]
 
-        uses_args = []
+        uses_args = %w[--formula --include-build --include-test]
         uses_args << "--recursive" unless args.skip_recursive_dependents?
         dependents = with_env(HOMEBREW_STDERR: "1") do
-          Utils.safe_popen_read("brew", "uses", "--include-build", "--include-test", *uses_args, formula_name)
+          Utils.safe_popen_read("brew", "uses", *uses_args, formula_name)
                .split("\n")
         end
         dependents -= @formulae


### PR DESCRIPTION
Only include formula dependents when determining which formulae to test. This solves the problems we've seen in https://github.com/Homebrew/homebrew-core/pull/66268 and https://github.com/Homebrew/homebrew-core/pull/66287.

This can't be merged until https://github.com/Homebrew/brew/pull/9437 is merged (which is what adds the `--formula` and `--cask` args to `brew uses`