### PR TITLE
Add HOMEBREW_REQUIRE_BOTTLED_ARM temporary environment variable

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -575,6 +575,15 @@ module Homebrew
           return
         end
 
+        if Hardware::CPU.arm? &&
+           ENV["HOMEBREW_REQUIRE_BOTTLED_ARM"] &&
+           !formula.bottled? &&
+           !formula.bottle_unneeded?
+          opoo "#{formula.full_name} has not yet been bottled on ARM!"
+          skip formula.name
+          return
+        end
+
         deps = []
         reqs = []
 


### PR DESCRIPTION
If `HOMEBREW_REQUIRE_BOTTLED_ARM` is set then don't build a given formula and just skip it. This allows Homebrew/core to prevent ARM bottles from regressing or not being updated while allowing new bottles from being built/tested in the dispatch workflow.