### PR TITLE
cleanup: speedup cleanup on GitHub Actions.

### DIFF
--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -23,7 +23,8 @@ module Homebrew
           # minimally fix brew doctor failures (a full clean takes ~5m)
           if OS.linux?
             # brew doctor complains
-            test "sudo", "rm", "-rf", "/usr/local/include/node/"
+            node = Pathname("/usr/local/include/node/")
+            test "sudo", "mv", node.to_s, "/tmp" if node.exist?
           elsif OS.mac?
             delete_or_move Pathname.glob(HOMEBREW_CELLAR/"*")
           end


### PR DESCRIPTION
- move instead of deleting taps and node includes (when sensible)
- don't run `brew cleanup` unless self-hosted