### PR TITLE
brew bottle: remove HOMEBREW_NO_PATCHELF_RB_WRITE

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -429,9 +429,7 @@ module Homebrew
         bottle_args << "--force-core-tap" if @test_default_formula
         bottle_args << "--root-url=#{root_url}" if root_url
         bottle_args << "--or-later" if args.or_later?
-        env = {}
-        env["HOMEBREW_NO_PATCHELF_RB_WRITE"] = "1" if ENV["HOMEBREW_PATCHELF_RB_WRITE"].blank?
-        test "brew", "bottle", *bottle_args, env: env
+        test "brew", "bottle", *bottle_args
 
         bottle_step = steps.last
         return unless bottle_step.passed?


### PR DESCRIPTION
This should revert this commit: https://github.com/Homebrew/homebrew-test-bot/pull/525#issuecomment-769695114 which disabled our Ruby implementation of `patchelf` when building in CI.  Now that we are confident this is working correctly correctly, we can allow the Ruby `patchelf` to be used in CI as well.