### PR TITLE
formulae: create failed dir only if nonexistent

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -656,7 +656,7 @@ module Homebrew
         if failed_linkage_or_test
           if @bottle_filename
             failed_dir = "#{File.dirname(@bottle_filename)}/failed"
-            FileUtils.mkdir failed_dir
+            FileUtils.mkdir failed_dir unless File.directory? failed_dir
             FileUtils.mv [@bottle_filename, @bottle_json_filename], failed_dir
           end
           return


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/10498.

I opted for a `File.directory?` check instead of `mkdir_p` since it seemed more transparent.