### PR TITLE
lib/test_bot: use Bootsnap.

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -52,6 +52,7 @@ module Homebrew
         raise UsageError, "cannot use --cleanup from HOMEBREW_PREFIX as it will delete all output."
       end
 
+      ENV["HOMEBREW_BOOTSNAP"] = "1"
       ENV["HOMEBREW_DEVELOPER"] = "1"
       ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
       ENV["HOMEBREW_NO_EMOJI"] = "1"


### PR DESCRIPTION
This produces massive initialisation speedups when repeatedly running `brew` commands like `brew test-bot` does.