### PR TITLE
lib/tests/formulae: don't error with if no tap is detected

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -587,6 +587,7 @@ module Homebrew
         end
 
         if OS.linux? &&
+           tap.present? &&
            tap.full_name == "Homebrew/homebrew-core" &&
            ENV["HOMEBREW_REQUIRE_BOTTLED_LINUX"] &&
            !formula.bottled? &&


### PR DESCRIPTION
Fixes broken `brew` CI