### PR TITLE
Split formulae step into multiple steps

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -59,10 +59,13 @@ module Homebrew
              description: "Only run the tap syntax check step."
       switch "--only-formulae",
              description: "Only run the formulae steps."
+      switch "--only-formulae-detect",
+             description: "Only run the formulae detection steps."
       switch "--only-cleanup-after",
              description: "Only run the post-cleanup step. Needs `--cleanup`."
       conflicts "--only-cleanup-before", "--only-setup", "--only-tap-syntax",
-                "--only-formulae", "--only-cleanup-after"
+                "--only-formulae", "--only-formulae-detect",
+                "--only-cleanup-after"
     end
   end
 

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -98,8 +98,7 @@ module Homebrew
         GIT, "-C", HOMEBREW_REPOSITORY.to_s,
         "log", "-1", "--format=%s"
       ).strip
-      verb = tap ? "Using" : "Testing"
-      puts Formatter.headline("#{verb} Homebrew/brew #{brew_version} (#{brew_commit_subject})", color: :cyan)
+      puts Formatter.headline("Using Homebrew/brew #{brew_version} (#{brew_commit_subject})", color: :cyan)
 
       if tap.to_s != CoreTap.instance.name
         core_revision = Utils.safe_popen_read(
@@ -110,21 +109,17 @@ module Homebrew
       end
 
       if tap
+        tap_github = " #{ENV["GITHUB_REPOSITORY"]}"
         tap_revision = Utils.safe_popen_read(
           GIT, "-C", tap.path.to_s,
           "log", "-1", "--format=%h (%s)"
         ).strip
-        puts Formatter.headline("Testing #{tap.full_name} #{tap_revision}:", color: :cyan)
+        puts Formatter.headline("Testing #{tap.full_name}#{tap_github} #{tap_revision}:", color: :cyan)
       end
 
       ENV["HOMEBREW_GIT_NAME"] = args.git_name || "BrewTestBot"
       ENV["HOMEBREW_GIT_EMAIL"] = args.git_email ||
                                   "1589480+BrewTestBot@users.noreply.github.com"
-
-      puts Formatter.headline("Tap configuration:", color: :cyan)
-      puts "GITHUB_REPOSITORY: #{ENV["GITHUB_REPOSITORY"]}"
-      puts "Core Tap: #{CoreTap.instance}"
-      puts "Found tap: #{tap}"
 
       Homebrew.failed = !TestRunner.run!(tap, git: GIT, args: args)
     ensure

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -3,20 +3,19 @@
 module Homebrew
   module Tests
     class Formulae < Test
+      attr_writer :formulae, :added_formulae, :deleted_formulae
+      attr_accessor :skipped_or_failed_formulae
+
       def initialize(argument, tap:, git:, dry_run:, fail_fast:, verbose:, bottle_output_path:)
         super(tap: tap, git: git, dry_run: dry_run, fail_fast: fail_fast, verbose: verbose)
 
         @argument = argument
         @bottle_output_path = bottle_output_path
 
-        @formulae = []
-        @added_formulae = []
-        @deleted_formulae = []
         @built_formulae = []
       end
 
       def run!(args:)
-        detect_formulae!(args: args)
         formulae.each do |f|
           formula!(f, args: args)
         end
@@ -27,161 +26,12 @@ module Homebrew
 
       private
 
-      def safe_formula_canonical_name(formula_name, args:)
-        Formulary.factory(formula_name).full_name
-      rescue TapFormulaUnavailableError => e
-        raise if e.tap.installed?
+      def skip(formula_name, extra_info: nil)
+        @skipped_or_failed_formulae << formula_name
 
-        test "brew", "tap", e.tap.name
-        retry unless steps.last.failed?
-        onoe e
-        puts e.backtrace if args.debug?
-      rescue FormulaUnavailableError, TapFormulaAmbiguityError,
-             TapFormulaWithOldnameAmbiguityError => e
-        onoe e
-        puts e.backtrace if args.debug?
-      end
-
-      def rev_parse(ref)
-        Utils.popen_read(git, "-C", repository, "rev-parse", "--verify", ref).strip
-      end
-
-      def current_sha1
-        rev_parse("HEAD")
-      end
-
-      def diff_formulae(start_revision, end_revision, path, filter)
-        return unless tap
-
-        Utils.safe_popen_read(
-          git, "-C", repository,
-          "diff-tree", "-r", "--name-only", "--diff-filter=#{filter}",
-          start_revision, end_revision, "--", path
-        ).lines.map do |line|
-          file = Pathname.new line.chomp
-          next unless tap.formula_file?(file)
-
-          tap.formula_file_to_name(file)
-        end.compact
-      end
-
-      def detect_formulae!(args:)
-        test_header(:Formulae, method: :detect_formulae!)
-
-        url = nil
-        origin_ref = "origin/master"
-
-        if @argument == "HEAD"
-          # Use GitHub Actions variables for pull request jobs.
-          if ENV["GITHUB_REF"].present? && ENV["GITHUB_REPOSITORY"].present? &&
-             %r{refs/pull/(?<pr>\d+)/merge} =~ ENV["GITHUB_REF"]
-            url = "https://github.com/#{ENV["GITHUB_REPOSITORY"]}/pull/#{pr}/checks"
-          end
-        elsif (canonical_formula_name = safe_formula_canonical_name(@argument, args: args))
-          @formulae = [canonical_formula_name]
-        else
-          raise UsageError,
-                "#{@argument} is not detected from GitHub Actions or a formula name!"
-        end
-
-        if ENV["GITHUB_REPOSITORY"].blank? || ENV["GITHUB_SHA"].blank? || ENV["GITHUB_REF"].blank?
-          if ENV["GITHUB_ACTIONS"]
-            odie <<~EOS
-              We cannot find the needed GitHub Actions environment variables! Check you have e.g. exported them to a Docker container.
-            EOS
-          elsif ENV["CI"]
-            onoe <<~EOS
-              No known CI provider detected! If you are using GitHub Actions then we cannot find the expected environment variables! Check you have e.g. exported them to a Docker container.
-            EOS
-          end
-        elsif tap.present? && tap.full_name.casecmp(ENV["GITHUB_REPOSITORY"]).zero?
-          # Use GitHub Actions variables for pull request jobs.
-          if ENV["GITHUB_BASE_REF"].present?
-            test git, "-C", repository, "fetch",
-                 "origin", "+refs/heads/#{ENV["GITHUB_BASE_REF"]}"
-            origin_ref = "origin/#{ENV["GITHUB_BASE_REF"]}"
-            diff_start_sha1 = rev_parse(origin_ref)
-            diff_end_sha1 = ENV["GITHUB_SHA"]
-          # Use GitHub Actions variables for branch jobs.
-          else
-            test git, "-C", repository, "fetch", "origin", "+#{ENV["GITHUB_REF"]}"
-            origin_ref = "origin/#{ENV["GITHUB_REF"].gsub(%r{^refs/heads/}, "")}"
-            diff_end_sha1 = diff_start_sha1 = ENV["GITHUB_SHA"]
-          end
-        end
-
-        if diff_start_sha1.present? && diff_end_sha1.present?
-          merge_base_sha1 =
-            Utils.safe_popen_read(git, "-C", repository, "merge-base",
-                                  diff_start_sha1, diff_end_sha1).strip
-          diff_start_sha1 = merge_base_sha1 if merge_base_sha1.present?
-        end
-
-        diff_start_sha1 = current_sha1 if diff_start_sha1.blank?
-        diff_end_sha1 = current_sha1 if diff_end_sha1.blank?
-
-        diff_start_sha1 = diff_end_sha1 if @formulae.present?
-
-        if tap
-          tap_origin_ref_revision_args =
-            [git, "-C", tap.path.to_s, "log", "-1", "--format=%h (%s)", origin_ref]
-          tap_origin_ref_revision = if args.dry_run?
-            # May fail on dry run as we've not fetched.
-            Utils.popen_read(*tap_origin_ref_revision_args).strip
-          else
-            Utils.safe_popen_read(*tap_origin_ref_revision_args)
-          end.strip
-          tap_revision = Utils.safe_popen_read(
-            git, "-C", tap.path.to_s,
-            "log", "-1", "--format=%h (%s)"
-          ).strip
-        end
-
-        puts <<-EOS
-    url             #{url.presence || "(undefined)"}
-    #{origin_ref}   #{tap_origin_ref_revision.presence || "(undefined)"}
-    HEAD            #{tap_revision.presence || "(undefined)"}
-    diff_start_sha1 #{diff_start_sha1.presence || "(undefined)"}
-    diff_end_sha1   #{diff_end_sha1.presence || "(undefined)"}
-        EOS
-
-        modified_formulae = []
-
-        if tap && diff_start_sha1 != diff_end_sha1
-          formula_path = tap.formula_dir.to_s
-          @added_formulae +=
-            diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "A")
-          modified_formulae +=
-            diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "M")
-          @deleted_formulae +=
-            diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "D")
-        end
-
-        if args.test_default_formula?
-          # Build the default test formula.
-          @test_default_formula = true
-          modified_formulae << "testbottest"
-        end
-
-        @formulae += @added_formulae + modified_formulae
-
-        if @formulae.blank? && @deleted_formulae.blank? && diff_start_sha1 == diff_end_sha1
-          raise UsageError, "Did not find any formulae or commits to test!"
-        end
-
-        info_header "Testing Formula changes:"
-        puts <<-EOS
-    added    #{@added_formulae.blank? ? "(empty)" : @added_formulae.join(" ")}
-    modified #{modified_formulae.blank? ? "(empty)" : modified_formulae.join(" ")}
-    deleted  #{@deleted_formulae.blank? ? "(empty)" : @deleted_formulae.join(" ")}
-        EOS
-      end
-
-      def skip(formula_name)
-        puts Formatter.headline(
-          "#{Formatter.warning("SKIPPED")} #{Formatter.identifier(formula_name)}",
-          color: :yellow,
-        )
+        text = "#{Formatter.warning("SKIPPED")} #{Formatter.identifier(formula_name)}"
+        text += " (#{extra_info})" if extra_info.present?
+        puts Formatter.headline(text, color: :yellow)
       end
 
       def satisfied_requirements?(formula, spec, dependency = nil)
@@ -194,9 +44,10 @@ module Homebrew
         return true if unsatisfied_requirements.empty?
 
         name = formula.full_name
-        name += " (#{spec})" unless stable_spec
-        name += " (#{dependency} dependency)" if dependency
-        skip name
+        extra_info = []
+        extra_info << spec.to_s unless stable_spec
+        extra_info << "#{dependency} dependency" if dependency
+        skip name, extra_info: extra_info.join(", ")
         puts unsatisfied_requirements.values.flatten.map(&:message)
         false
       end

--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module Homebrew
+  module Tests
+    class FormulaeDetect < Test
+      attr_reader :formulae, :added_formulae, :deleted_formulae
+
+      def initialize(argument, tap:, git:, dry_run:, fail_fast:, verbose:)
+        super(tap: tap, git: git, dry_run: dry_run, fail_fast: fail_fast, verbose: verbose)
+
+        @argument = argument
+
+        @added_formulae = []
+        @deleted_formulae = []
+        @built_formulae = []
+      end
+
+      def run!(args:)
+        detect_formulae!(args: args)
+      end
+
+      private
+
+      def detect_formulae!(args:)
+        test_header(:Formulae, method: :detect_formulae!)
+
+        url = nil
+        origin_ref = "origin/master"
+
+        if @argument == "HEAD"
+          @formulae = []
+          # Use GitHub Actions variables for pull request jobs.
+          if ENV["GITHUB_REF"].present? && ENV["GITHUB_REPOSITORY"].present? &&
+             %r{refs/pull/(?<pr>\d+)/merge} =~ ENV["GITHUB_REF"]
+            url = "https://github.com/#{ENV["GITHUB_REPOSITORY"]}/pull/#{pr}/checks"
+          end
+        elsif (canonical_formula_name = safe_formula_canonical_name(@argument, args: args))
+          @formulae = [canonical_formula_name]
+        else
+          raise UsageError,
+                "#{@argument} is not detected from GitHub Actions or a formula name!"
+        end
+
+        if ENV["GITHUB_REPOSITORY"].blank? || ENV["GITHUB_SHA"].blank? || ENV["GITHUB_REF"].blank?
+          if ENV["GITHUB_ACTIONS"]
+            odie <<~EOS
+              We cannot find the needed GitHub Actions environment variables! Check you have e.g. exported them to a Docker container.
+            EOS
+          elsif ENV["CI"]
+            onoe <<~EOS
+              No known CI provider detected! If you are using GitHub Actions then we cannot find the expected environment variables! Check you have e.g. exported them to a Docker container.
+            EOS
+          end
+        elsif tap.present? && tap.full_name.casecmp(ENV["GITHUB_REPOSITORY"]).zero?
+          # Use GitHub Actions variables for pull request jobs.
+          if ENV["GITHUB_BASE_REF"].present?
+            test git, "-C", repository, "fetch",
+                 "origin", "+refs/heads/#{ENV["GITHUB_BASE_REF"]}"
+            origin_ref = "origin/#{ENV["GITHUB_BASE_REF"]}"
+            diff_start_sha1 = rev_parse(origin_ref)
+            diff_end_sha1 = ENV["GITHUB_SHA"]
+          # Use GitHub Actions variables for branch jobs.
+          else
+            test git, "-C", repository, "fetch", "origin", "+#{ENV["GITHUB_REF"]}"
+            origin_ref = "origin/#{ENV["GITHUB_REF"].gsub(%r{^refs/heads/}, "")}"
+            diff_end_sha1 = diff_start_sha1 = ENV["GITHUB_SHA"]
+          end
+        end
+
+        if diff_start_sha1.present? && diff_end_sha1.present?
+          merge_base_sha1 =
+            Utils.safe_popen_read(git, "-C", repository, "merge-base",
+                                  diff_start_sha1, diff_end_sha1).strip
+          diff_start_sha1 = merge_base_sha1 if merge_base_sha1.present?
+        end
+
+        diff_start_sha1 = current_sha1 if diff_start_sha1.blank?
+        diff_end_sha1 = current_sha1 if diff_end_sha1.blank?
+
+        diff_start_sha1 = diff_end_sha1 if @formulae.present?
+
+        if tap
+          tap_origin_ref_revision_args =
+            [git, "-C", tap.path.to_s, "log", "-1", "--format=%h (%s)", origin_ref]
+          tap_origin_ref_revision = if args.dry_run?
+            # May fail on dry run as we've not fetched.
+            Utils.popen_read(*tap_origin_ref_revision_args).strip
+          else
+            Utils.safe_popen_read(*tap_origin_ref_revision_args)
+          end.strip
+          tap_revision = Utils.safe_popen_read(
+            git, "-C", tap.path.to_s,
+            "log", "-1", "--format=%h (%s)"
+          ).strip
+        end
+
+        puts <<-EOS
+    url             #{url.presence                     || "(blank)"}
+    #{origin_ref}   #{tap_origin_ref_revision.presence || "(blank)"}
+    HEAD            #{tap_revision.presence            || "(blank)"}
+    diff_start_sha1 #{diff_start_sha1.presence         || "(blank)"}
+    diff_end_sha1   #{diff_end_sha1.presence           || "(blank)"}
+        EOS
+
+        modified_formulae = []
+
+        if tap && diff_start_sha1 != diff_end_sha1
+          formula_path = tap.formula_dir.to_s
+          @added_formulae +=
+            diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "A")
+          modified_formulae +=
+            diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "M")
+          @deleted_formulae +=
+            diff_formulae(diff_start_sha1, diff_end_sha1, formula_path, "D")
+        end
+
+        if args.test_default_formula?
+          # Build the default test formula.
+          @test_default_formula = true
+          modified_formulae << "testbottest"
+        end
+
+        @formulae += @added_formulae + modified_formulae
+
+        if @formulae.blank? && @deleted_formulae.blank? && diff_start_sha1 == diff_end_sha1
+          raise UsageError, "Did not find any formulae or commits to test!"
+        end
+
+        info_header "Testing Formula changes:"
+        puts <<-EOS
+    formulae  #{@formulae.blank?         ? "(blank)" : @formulae.join(" ")}
+    added     #{@added_formulae.blank?   ? "(blank)" : @added_formulae.join(" ")}
+    modified  #{modified_formulae.blank? ? "(blank)" : modified_formulae.join(" ")}
+    deleted   #{@deleted_formulae.blank? ? "(blank)" : @deleted_formulae.join(" ")}
+        EOS
+      end
+
+      def safe_formula_canonical_name(formula_name, args:)
+        Formulary.factory(formula_name).full_name
+      rescue TapFormulaUnavailableError => e
+        raise if e.tap.installed?
+
+        test "brew", "tap", e.tap.name
+        retry unless steps.last.failed?
+        onoe e
+        puts e.backtrace if args.debug?
+      rescue FormulaUnavailableError, TapFormulaAmbiguityError,
+             TapFormulaWithOldnameAmbiguityError => e
+        onoe e
+        puts e.backtrace if args.debug?
+      end
+
+      def rev_parse(ref)
+        Utils.popen_read(git, "-C", repository, "rev-parse", "--verify", ref).strip
+      end
+
+      def current_sha1
+        rev_parse("HEAD")
+      end
+
+      def diff_formulae(start_revision, end_revision, path, filter)
+        return unless tap
+
+        Utils.safe_popen_read(
+          git, "-C", repository,
+          "diff-tree", "-r", "--name-only", "--diff-filter=#{filter}",
+          start_revision, end_revision, "--", path
+        ).lines.map do |line|
+          file = Pathname.new line.chomp
+          next unless tap.formula_file?(file)
+
+          tap.formula_file_to_name(file)
+        end.compact
+      end
+    end
+  end
+end


### PR DESCRIPTION
This splits the current `--only-formulae` step into `--only-formulae` and `--only-formulae-detect`. This will allow the failures to be more obvious on whether they are due the detection of the changed formulae.

In a future PR I hope to split out `--only-formulae-bottle` and `--only-formulae-dependents`.  This will allow the failures to be more obvious on whether they are due to the changed formulae failing, the dependents of these formulae (or the detection of the changed formulae).

This future PR work should provide a few benefits:
- in future potentially cache the changed formulae bottles to avoid rebuilding them every time if they were built successfully last time (speeding up large PR rebuilds)
- in future potentially parallelising the dependent testing across multiple jobs/runners
- generally split up a large, hugely complex class

`--only-formulae` should do the same thing it has always done after this PR is merged.