### PR TITLE
lib/test_ci_upload: fix error after brew changes

### DIFF
--- a/lib/test_ci_upload.rb
+++ b/lib/test_ci_upload.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "github_releases"
+
 module Homebrew
   module TestCiUpload
     module_function
@@ -40,7 +42,7 @@ module Homebrew
       bottles_hash.each do |_, bottle_hash|
         root_url = bottle_hash["bottle"]["root_url"]
 
-        next unless root_url.match HOMEBREW_RELEASES_URL_REGEX
+        next unless root_url.match GitHubReleases::URL_REGEX
 
         odie "Refusing to upload to GitHub Releases, use `brew pr-upload`."
       end

--- a/spec/stub/github_releases.rb
+++ b/spec/stub/github_releases.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# Intentionally empty for no-op require.


### PR DESCRIPTION
Probably worth deprecating this at some point, signposting taps to use `brew pr-upload`.