### PR TITLE
lib/tests/formulae: remove old --or-later reference

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -430,7 +430,6 @@ module Homebrew
         bottle_args << "--skip-relocation" if args.skip_relocation?
         bottle_args << "--force-core-tap" if @test_default_formula
         bottle_args << "--root-url=#{root_url}" if root_url
-        bottle_args << "--or-later" if args.or_later?
         test "brew", "bottle", *bottle_args
 
         bottle_step = steps.last


### PR DESCRIPTION
Caught by https://github.com/Homebrew/brew/pull/10880.