### PR TITLE
lib/tests/formulae: change cleanup_during margin to 10GB

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -705,11 +705,11 @@ module Homebrew
         return unless args.cleanup?
         return unless HOMEBREW_CACHE.exist?
 
-        used_percentage = Utils.safe_popen_read("df", HOMEBREW_CACHE.to_s)
-                               .lines[1] # HOMEBREW_CACHE
-                               .split[4] # used %
-                               .to_i
-        return if used_percentage < 95
+        free_gb = Utils.safe_popen_read({ "BLOCKSIZE" => (1000 ** 3).to_s }, "df", HOMEBREW_CACHE.to_s)
+                       .lines[1] # HOMEBREW_CACHE
+                       .split[3] # free GB
+                       .to_i
+        return if free_gb < 10
 
         test_header(:Formulae, method: :cleanup_during!)
 


### PR DESCRIPTION
95% means only 5GB free. Legacy LLVM versions (`llvm@9`, `llvm@8`) during a Python update needs a bit more than that, particularly since they're based on the old static-linking way of building which I didn't backport (and I probably won't for compatibility reasons).

90% is about 10GB free which most builds should be able to operate in.

The runtime cost of running this a tad more often seems negligible. It can be optimised in a similar manner to `Mktemp`'s cleanup if need be.