### PR TITLE
Optionally build bottles with `--only-json-tab`

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -26,6 +26,8 @@ module Homebrew
              description: "Run `brew bottle --keep-old` to build new bottles for a single platform."
       switch "--skip-relocation",
              description: "Run `brew bottle --skip-relocation` to build new bottles that don't require relocation."
+      switch "--only-json-tab",
+             description: "Run `brew bottle --only-json-tab` to build new bottles that do not contain a tab."
       switch "--local",
              description: "Ask Homebrew to write verbose logs under `./logs/` and set `$HOME` to `./home/`"
       flag   "--tap=",

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -430,6 +430,7 @@ module Homebrew
         bottle_args << "--skip-relocation" if args.skip_relocation?
         bottle_args << "--force-core-tap" if @test_default_formula
         bottle_args << "--root-url=#{root_url}" if root_url
+        bottle_args << "--only-json-tab" if args.only_json_tab?
         test "brew", "bottle", *bottle_args
 
         bottle_step = steps.last


### PR DESCRIPTION
Provide option to pass `--only-json-tab` to bottles (so they can be built reproducibly).

After this is merged: I'll open a PR to enable this on Homebrew/homebrew-core.