### PR TITLE
Write `brew bottle` output to text file.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,9 +58,9 @@ jobs:
             docker run \
               -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
               --rm brew \
-              brew test-bot --test-default-formula
+              brew test-bot --only-formulae --test-default-formula
           else
-            brew test-bot --test-default-formula
+            brew test-bot --only-formulae --test-default-formula
           fi
 
       - name: Output brew test-bot failures
@@ -68,6 +68,12 @@ jobs:
         run: |
           cat steps_output.txt
           rm steps_output.txt
+
+      - name: Output brew bottle output
+        if: matrix.os == 'macOS-latest'
+        run: |
+          cat bottle_output.txt
+          rm bottle_output.txt
 
       - name: Run brew test-bot --only-cleanup-after
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage/
+bottle_output.txt
 steps_output.txt

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -3,10 +3,11 @@
 module Homebrew
   module Tests
     class Formulae < Test
-      def initialize(argument, tap:, git:, dry_run:, fail_fast:, verbose:)
+      def initialize(argument, tap:, git:, dry_run:, fail_fast:, verbose:, bottle_output_path:)
         super(tap: tap, git: git, dry_run: dry_run, fail_fast: fail_fast, verbose: verbose)
 
         @argument = argument
+        @bottle_output_path = bottle_output_path
 
         @formulae = []
         @added_formulae = []
@@ -439,6 +440,8 @@ module Homebrew
         bottle_step = steps.last
         return unless bottle_step.passed?
         return unless bottle_step.output?
+
+        @bottle_output_path.write(bottle_step.output, mode: "a")
 
         @bottle_filename =
           bottle_step.output


### PR DESCRIPTION
I think this will be useful to not only quickly see the checksums of the bottles, but also see what is preventing the bottle from being relocatable.

Requires https://github.com/Homebrew/brew/pull/11307