### PR TITLE
lib/tests/formulae: build emscripten deps from source

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -305,6 +305,7 @@ module Homebrew
         build_dependents_from_source_allowlist = %w[
           cabal-install
           docbook-xsl
+          emscripten
           erlang
           ghc
           go


### PR DESCRIPTION
This allows us to catch breakage from new versions of emscripten. See,
for example, https://github.com/Homebrew/discussions/discussions/1488.

Currently, this applies to only one formula (`tree-sitter`).