### PR TITLE
Exclude version audit

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -12,7 +12,7 @@ module Homebrew
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
         test "brew", "style", tap.name unless broken_xcode_rubygems
 
-        test "brew", "audit", "--tap=#{tap.name}"
+        test "brew", "audit", "--tap=#{tap.name}", "--except=version"
       end
     end
   end


### PR DESCRIPTION
This PR modifies `test-bot` to exclude `ResourceAuditor#audit_version` where `brew audit` is run for existing formulae, so we avoid this audit on core CI. The version audit should still be run for new formulae, as we want to ensure that we catch an unnecessary `version`.

A detailed explanation of the reasoning behind this change can be found in Homebrew/brew#11542. It's fine to merge this test-bot PR independently and the version audit will be skipped after the brew PR is merged (as `ResourceAuditor` will start receiving the `--only` and `--except` options).

I'm not very familiar with `test-bot`'s internals, so any feedback on whether I've modified the correct `brew audit` calls would be appreciated.