### PR TITLE
Delete --bintray-org --ci-upload arguments.

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -39,16 +39,12 @@ module Homebrew
                           "passing output as raw bytes instead of re-encoding in UTF-8."
       switch "--test-default-formula",
              description: "Use a default testing formula when not building a tap and no other formulae are specified."
-      flag   "--bintray-org=",
-             description: "Upload bottles to the given Bintray organisation."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--git-name=",
              description: "Set the Git author/committer names to the given name."
       flag   "--git-email=",
              description: "Set the Git author/committer email to the given email."
-      switch "--ci-upload",
-             description: "Use the Homebrew CI bottle upload options."
       switch "--publish",
              description: "Publish the uploaded bottles."
       switch "--skip-recursive-dependents",

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -121,11 +121,6 @@ module Homebrew
       ENV["HOMEBREW_GIT_EMAIL"] = args.git_email ||
                                   "1589480+BrewTestBot@users.noreply.github.com"
 
-      if args.ci_upload?
-        odisabled "brew test-bot --ci-upload (Bintray will be shut down on 1st May 2021)"
-        return
-      end
-
       Homebrew.failed = !TestRunner.run!(tap, git: GIT, args: args)
     ensure
       if HOMEBREW_CACHE.exist?

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -422,7 +422,7 @@ module Homebrew
         root_url = args.root_url
 
         # GitHub Releases url
-        root_url ||= if tap.present? && !tap.core_tap? && !args.bintray_org && !@test_default_formula
+        root_url ||= if tap.present? && !tap.core_tap? && !@test_default_formula
           "#{tap.default_remote}/releases/download/#{formula.name}-#{formula.pkg_version}"
         end
 


### PR DESCRIPTION
These were both disabled and now Bintray has been shut down for over a month and a half.