### PR TITLE
Rename ENV var to skip unbottled ARM tests

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -583,8 +583,10 @@ module Homebrew
         end
         new_formula = @added_formulae.include?(formula_name)
 
+        # TODO: Remove ENV["HOMEBREW_REQUIRE_BOTTLED_ARM"] from the condition
+        # below once it's no longer used.
         if Hardware::CPU.arm? &&
-           ENV["HOMEBREW_REQUIRE_BOTTLED_ARM"] &&
+           (ENV["HOMEBREW_SKIP_UNBOTTLED_ARM_TESTS"] || ENV["HOMEBREW_REQUIRE_BOTTLED_ARM"]) &&
            !formula.bottled? &&
            !formula.bottle_unneeded? &&
            !new_formula

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -598,7 +598,7 @@ module Homebrew
         if OS.linux? &&
            tap.present? &&
            tap.full_name == "Homebrew/homebrew-core" &&
-           ENV["HOMEBREW_REQUIRE_BOTTLED_LINUX"] &&
+           ENV["HOMEBREW_SKIP_UNBOTTLED_LINUX_TESTS"] &&
            !formula.bottled? &&
            !formula.bottle_unneeded?
           opoo "#{formula.full_name} has not yet been bottled on Linux!"


### PR DESCRIPTION
In relation to some [recent discussion about the `HOMEBREW_REQUIRE_BOTTLED_ARM` environment variable name](https://github.com/Homebrew/homebrew-core/pull/79458#discussion_r653131335), this PR modifies the related test-bot code to allow for an alternative `HOMEBREW_SKIP_UNBOTTLED_ARM_TESTS` environment variable.

This is intended to replace the existing environment variable but we'll need to temporarily allow both during the transition period. I added a preceding `TODO` comment that makes this clear.

I know this environment variable is set in homebrew/core's [`tests` workflow](https://github.com/Homebrew/homebrew-core/blob/1956fde72bb034d0f5688a8d2005fdb6f505516a/.github/workflows/tests.yml#L115) but are there any other areas that we would need to update as well?