### PR TITLE
Remove old ENV var to skip unbottled ARM tests

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -583,10 +583,8 @@ module Homebrew
         end
         new_formula = @added_formulae.include?(formula_name)
 
-        # TODO: Remove ENV["HOMEBREW_REQUIRE_BOTTLED_ARM"] from the condition
-        # below once it's no longer used.
         if Hardware::CPU.arm? &&
-           (ENV["HOMEBREW_SKIP_UNBOTTLED_ARM_TESTS"] || ENV["HOMEBREW_REQUIRE_BOTTLED_ARM"]) &&
+           ENV["HOMEBREW_SKIP_UNBOTTLED_ARM_TESTS"] &&
            !formula.bottled? &&
            !formula.bottle_unneeded? &&
            !new_formula


### PR DESCRIPTION
This is a follow-up to #619, which added support for a `HOMEBREW_SKIP_UNBOTTLED_ARM_TESTS` environment variable, as a way of renaming `HOMEBREW_REQUIRE_BOTTLED_ARM`.

After that PR was merged, we replaced usage of this environment variable in homebrew/core (in the `tests.yml` workflow), which appears to be the only place this is used. With that done, this PR removes support for the old `HOMEBREW_REQUIRE_BOTTLED_ARM` environment variable, as it's no longer used.