### PR TITLE
Add JUnit output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage/
 bottle_output.txt
+brew-test-bot.xml
 steps_output.txt

--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -22,6 +22,8 @@ module Homebrew
              description: "Don't check if the local system is set up correctly."
       switch "--build-from-source",
              description: "Build from source rather than building bottles."
+      switch "--junit",
+             description: "generate a JUnit XML test results file."
       switch "--keep-old",
              description: "Run `brew bottle --keep-old` to build new bottles for a single platform."
       switch "--skip-relocation",

--- a/lib/junit.rb
+++ b/lib/junit.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rexml/document"
+require "rexml/xmldecl"
+require "rexml/cdata"
+
+module Homebrew
+  class Junit
+    BYTES_IN_1_MEGABYTE = 1024*1024
+    MAX_STEP_OUTPUT_SIZE = (BYTES_IN_1_MEGABYTE - (200*1024)).freeze # margin of safety
+
+    def initialize(tests)
+      @tests = tests
+    end
+
+    def build(filters: nil)
+      filters ||= []
+
+      @xml_document = REXML::Document.new
+      @xml_document << REXML::XMLDecl.new
+      testsuites = @xml_document.add_element "testsuites"
+
+      @tests.each do |test|
+        testsuite = testsuites.add_element "testsuite"
+        testsuite.add_attribute "name", "brew-test-bot.#{Utils::Bottles.tag}"
+        testsuite.add_attribute "tests", test.steps.count(&:passed?)
+        testsuite.add_attribute "failures", test.steps.count(&:failed?)
+        testsuite.add_attribute "timestamp", test.steps.first.start_time.iso8601
+
+        test.steps.each do |step|
+          next unless filters.any? { |filter| step.command_short.start_with? filter }
+
+          testcase = testsuite.add_element "testcase"
+          testcase.add_attribute "name", step.command_short
+          testcase.add_attribute "status", step.status
+          testcase.add_attribute "time", step.time
+          testcase.add_attribute "timestamp", step.start_time.iso8601
+
+          next unless step.output?
+
+          output = sanitize_output_for_xml(step.output)
+          cdata = REXML::CData.new output
+
+          if step.passed?
+            elem = testcase.add_element "system-out"
+          else
+            elem = testcase.add_element "failure"
+            elem.add_attribute "message",
+                               "#{step.status}: #{step.command.join(" ")}"
+          end
+
+          elem << cdata
+        end
+      end
+    end
+
+    def write(filename)
+      output_path = Pathname(filename)
+      output_path.unlink if output_path.exist?
+      output_path.open("w") do |xml_file|
+        pretty_print_indent = 2
+        @xml_document.write(xml_file, pretty_print_indent)
+      end
+    end
+
+    private
+
+    def sanitize_output_for_xml(output)
+      return output if output.blank?
+
+      # Remove invalid XML CData characters from step output.
+      invalid_xml_pat =
+        /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/
+      output.gsub!(invalid_xml_pat, "\uFFFD")
+
+      return output if output.bytesize <= MAX_STEP_OUTPUT_SIZE
+
+      # Truncate to 1MB to avoid hitting CI limits
+      output =
+        truncate_text_to_approximate_size(
+          output, MAX_STEP_OUTPUT_SIZE, front_weight: 0.0
+        )
+      "truncated output to 1MB:\n#{output}"
+    end
+  end
+end

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -6,9 +6,11 @@ module Homebrew
       @steps.select(&:failed?)
     end
 
-    protected
+    attr_reader :steps
 
-    attr_reader :tap, :git, :steps, :repository
+    private
+
+    attr_reader :tap, :git, :repository
 
     def initialize(tap: nil, git: nil, dry_run: false, fail_fast: false, verbose: false)
       @tap = tap

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "junit"
 require_relative "test"
 require_relative "test_cleanup"
 require_relative "tests/cleanup_after"
@@ -61,6 +62,13 @@ module Homebrew
       steps_output_path = Pathname("steps_output.txt")
       steps_output_path.unlink if steps_output_path.exist?
       steps_output_path.write(steps_output)
+
+      if args.junit?
+        junit_filters = %w[audit test]
+        junit = ::Homebrew::Junit.new(tests)
+        junit.build(filters: junit_filters)
+        junit.write("brew-test-bot.xml")
+      end
 
       failed_steps.empty?
     end


### PR DESCRIPTION
This PR adds (or rather brings back) an ability to save `homebrew-test-bot` test results in JUnit format.
Most of the code is copied from the previous version (from https://github.com/Homebrew/homebrew-test-bot/pull/355) with some small adjustments:
- All JUnit related code moved to `lib/junit.rb`
- JUnit reporter supports filtering tests by name (currently is saves results only for `audit` and `test`)

See https://github.com/Homebrew/brew/pull/11578#pullrequestreview-689543802