### PR TITLE
tests: modify dependents lists only in linuxbrew-core

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -295,7 +295,9 @@ module Homebrew
         @unchanged_build_dependencies = build_dependencies - @formulae
 
         # Test reverse dependencies for linux-only formulae in linuxbrew-core.
-        if args.keep_old? && formula.requirements.exclude?(LinuxRequirement.new)
+        if tap.full_name == "Homebrew/linuxbrew-core" &&
+           args.keep_old? &&
+           formula.requirements.exclude?(LinuxRequirement.new)
           @testable_dependents = @bottled_dependents = @source_dependents = []
           return
         end


### PR DESCRIPTION
The lists of dependents are reset to avoid long-running builds in linuxbrew-core.
Run that part of the code only in linuxbrew-core