### PR TITLE
tests: add some debug output

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -379,13 +379,13 @@ module Homebrew
         end
         @testable_dependents += @bottled_dependents.select(&:test_defined?)
 
-        info_header "Source dependents"
+        info_header "Source dependents:"
         puts @source_dependents
 
-        info_header "Bottled dependents"
+        info_header "Bottled dependents:"
         puts @bottled_dependents
 
-        info_header "Testable dependents"
+        info_header "Testable dependents:"
         puts @testable_dependents
       end
 

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -378,6 +378,15 @@ module Homebrew
           dependents.select(&:bottled?)
         end
         @testable_dependents += @bottled_dependents.select(&:test_defined?)
+
+        info_header "Source dependents"
+        puts @source_dependents
+
+        info_header "Bottled dependents"
+        puts @bottled_dependents
+
+        info_header "Testable dependents"
+        puts @testable_dependents
       end
 
       def unlink_conflicts(formula)


### PR DESCRIPTION
This can be reverted if we think it is useless,
but I have been asking myself many times why
some dependents are being tested.

This should also help debug an issue we have right now with
homebrew-core.