### PR TITLE
tests: add tap debug

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -121,6 +121,11 @@ module Homebrew
       ENV["HOMEBREW_GIT_EMAIL"] = args.git_email ||
                                   "1589480+BrewTestBot@users.noreply.github.com"
 
+      puts Formatter.headline("Tap configuration:", color: :cyan)
+      puts "GITHUB_REPOSITORY: #{ENV["GITHUB_REPOSITORY"]}"
+      puts "Core Tap: #{CoreTap.instance}"
+      puts "Found tap: #{tap}"
+
       Homebrew.failed = !TestRunner.run!(tap, git: GIT, args: args)
     ensure
       if HOMEBREW_CACHE.exist?


### PR DESCRIPTION
I am trying to find out why tap is not set on linux CI for homebrew-core