### PR TITLE
Split out formulae dependents.

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -61,6 +61,8 @@ module Homebrew
              description: "Only run the formulae steps."
       switch "--only-formulae-detect",
              description: "Only run the formulae detection steps."
+      switch "--only-formulae-dependents",
+             description: "Only run the formulae dependents steps."
       switch "--only-cleanup-after",
              description: "Only run the post-cleanup step. Needs `--cleanup`."
       conflicts "--only-cleanup-before", "--only-setup", "--only-tap-syntax",

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Homebrew
+  module Tests
+    class TestFormulae < Test
+      attr_accessor :skipped_or_failed_formulae
+
+      def initialize(tap:, git:, dry_run:, fail_fast:, verbose:)
+        super
+
+        @skipped_or_failed_formulae = []
+      end
+
+      protected
+
+      def skipped(formula_name, reason)
+        @skipped_or_failed_formulae << formula_name
+
+        puts Formatter.headline(
+          "#{Formatter.warning("SKIPPED")} #{Formatter.identifier(formula_name)}",
+          color: :yellow,
+        )
+        opoo reason
+      end
+
+      def failed(formula_name, reason)
+        @skipped_or_failed_formulae << formula_name
+
+        puts Formatter.headline(
+          "#{Formatter.error("FAILED")} #{Formatter.identifier(formula_name)}",
+          color: :red,
+        )
+        onoe reason
+      end
+
+      def unsatisfied_requirements_messages(formula)
+        f = Formulary.factory(formula.full_name)
+        fi = FormulaInstaller.new(f)
+        fi.build_bottle = true
+
+        unsatisfied_requirements, = fi.expand_requirements
+        return if unsatisfied_requirements.blank?
+
+        unsatisfied_requirements.values.flatten.map(&:message).presence
+      end
+
+      def cleanup_during!(args:)
+        return unless args.cleanup?
+        return unless HOMEBREW_CACHE.exist?
+
+        free_gb = Utils.safe_popen_read({ "BLOCKSIZE" => (1000 ** 3).to_s }, "df", HOMEBREW_CACHE.to_s)
+                       .lines[1] # HOMEBREW_CACHE
+                       .split[3] # free GB
+                       .to_i
+        return if free_gb > 10
+
+        test_header(:TestFormulae, method: :cleanup_during!)
+
+        FileUtils.chmod_R "u+rw", HOMEBREW_CACHE, force: true
+        test "rm", "-rf", HOMEBREW_CACHE.to_s
+      end
+    end
+  end
+end

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+module Homebrew
+  module Tests
+    class FormulaeDependents < TestFormulae
+      attr_writer :testing_formulae
+
+      def run!(args:)
+        (@testing_formulae - skipped_or_failed_formulae).each do |f|
+          dependent_formulae!(f, args: args)
+        end
+      end
+
+      private
+
+      def dependent_formulae!(formula_name, args:)
+        cleanup_during!(args: args)
+
+        test_header(:FormulaeDependents, method: "dependent_formulae!(#{formula_name})")
+
+        formula = Formulary.factory(formula_name)
+
+        source_dependents, bottled_dependents, testable_dependents =
+          dependents_for_formula(formula, formula_name, args: args)
+
+        source_dependents.each do |dependent|
+          install_dependent(dependent, testable_dependents, build_from_source: true, args: args)
+
+          bottled = with_env(HOMEBREW_SKIP_OR_LATER_BOTTLES: "1") do
+            dependent.bottled?
+          end
+          install_dependent(dependent, testable_dependents, args: args) if bottled
+        end
+
+        bottled_dependents.each do |dependent|
+          install_dependent(dependent, testable_dependents, args: args)
+        end
+      end
+
+      def dependents_for_formula(formula, formula_name, args:)
+        info_header "Determining dependents..."
+
+        # Test reverse dependencies for linux-only formulae in linuxbrew-core.
+        if tap.present? &&
+           tap.full_name == "Homebrew/linuxbrew-core" &&
+           args.keep_old? &&
+           formula.requirements.exclude?(LinuxRequirement.new)
+          return [[], [], []]
+        end
+
+        # TODO: move this to a JSON file in homebrew/core or GitHub label
+        build_dependents_from_source_allowlist = %w[
+          cabal-install
+          docbook-xsl
+          emscripten
+          erlang
+          ghc
+          go
+          ocaml
+          ocaml-findlib
+          ocaml-num
+          openjdk
+          rust
+        ]
+
+        if OS.linux? && tap.present? && tap.full_name == "Homebrew/homebrew-core"
+          build_dependents_from_source_allowlist = []
+        end
+
+        uses_args = %w[--formula --include-build --include-test]
+        uses_args << "--recursive" unless args.skip_recursive_dependents?
+        dependents = with_env(HOMEBREW_STDERR: "1") do
+          Utils.safe_popen_read("brew", "uses", *uses_args, formula_name)
+               .split("\n")
+        end
+        dependents -= @testing_formulae
+        dependents = dependents.map { |d| Formulary.factory(d) }
+
+        dependents = dependents.zip(dependents.map do |f|
+          if args.skip_recursive_dependents?
+            f.deps
+          else
+            begin
+              f.recursive_dependencies
+            rescue TapFormulaUnavailableError => e
+              raise if e.tap.installed?
+
+              e.tap.clear_cache
+              safe_system "brew", "tap", e.tap.name
+              retry
+            end
+          end.reject(&:optional?)
+        end)
+
+        # Split into dependents that we could potentially be building from source and those
+        # we should not. The criteria is that it depends on a formula in the allowlist and
+        # that formula has been, or will be, built in this test run.
+        source_dependents, dependents = dependents.partition do |_, deps|
+          deps.any? do |d|
+            full_name = d.to_formula.full_name
+
+            next false unless build_dependents_from_source_allowlist.include?(full_name)
+
+            @testing_formulae.include?(full_name)
+          end
+        end
+
+        # From the non-source list, get rid of any dependents we are only a build dependency to
+        dependents.select! do |_, deps|
+          deps.reject { |d| d.build? && !d.test? }
+              .map(&:to_formula)
+              .include?(formula)
+        end
+
+        dependents = dependents.transpose.first.to_a
+        source_dependents = source_dependents.transpose.first.to_a
+
+        testable_dependents = source_dependents.select(&:test_defined?)
+        bottled_dependents = with_env(HOMEBREW_SKIP_OR_LATER_BOTTLES: "1") do
+          if OS.linux? &&
+             tap.present? &&
+             tap.full_name == "Homebrew/homebrew-core"
+            # :all bottles are considered as Linux bottles, but as we did not bottle
+            # everything (yet) in homebrew-core, we do not want to test formulae
+            # with :all bottles for the time being.
+            dependents.select { |dep| dep.bottled? && !dep.bottle_specification.tag?(:all) }
+          else
+            dependents.select(&:bottled?)
+          end
+        end
+        testable_dependents += bottled_dependents.select(&:test_defined?)
+
+        info_header "Source dependents:"
+        puts source_dependents
+
+        info_header "Bottled dependents:"
+        puts bottled_dependents
+
+        info_header "Testable dependents:"
+        puts testable_dependents
+
+        [source_dependents, bottled_dependents, testable_dependents]
+      end
+
+      def install_dependent(dependent, testable_dependents, args:, build_from_source: false)
+        if (messages = unsatisfied_requirements_messages(dependent))
+          skipped dependent, messages
+          return
+        end
+
+        if dependent.deprecated? || dependent.disabled?
+          verb = dependent.deprecated? ? :deprecated : :disabled
+          skipped dependent.name, "#{dependent.full_name} has been #{verb}!"
+          return
+        end
+
+        cleanup_during!(args: args)
+
+        unless dependent.latest_version_installed?
+          build_args = []
+          build_args << "--build-from-source" if build_from_source
+
+          test "brew", "fetch", *build_args, "--retry", dependent.full_name
+          return if steps.last.failed?
+
+          unlink_conflicts dependent
+
+          test "brew", "install", *build_args, "--only-dependencies", dependent.full_name,
+               env:  { "HOMEBREW_DEVELOPER" => nil }
+          test "brew", "install", *build_args, dependent.full_name,
+               env:  { "HOMEBREW_DEVELOPER" => nil }
+          return if steps.last.failed?
+        end
+        return unless dependent.latest_version_installed?
+
+        if !dependent.keg_only? && !dependent.linked_keg.exist?
+          unlink_conflicts dependent
+          test "brew", "link", dependent.full_name
+        end
+        test "brew", "install", "--only-dependencies", dependent.full_name
+        test "brew", "linkage", "--test", dependent.full_name
+
+        if testable_dependents.include? dependent
+          test "brew", "install", "--only-dependencies", "--include-test",
+               dependent.full_name
+          test "brew", "test", "--retry", "--verbose", dependent.full_name
+        end
+
+        test "brew", "uninstall", "--force", dependent.full_name
+      end
+
+      def unlink_conflicts(formula)
+        return if formula.keg_only?
+        return if formula.linked_keg.exist?
+
+        conflicts = formula.conflicts.map { |c| Formulary.factory(c.name) }
+                           .select(&:any_version_installed?)
+        formula_recursive_dependencies = begin
+          formula.recursive_dependencies
+        rescue TapFormulaUnavailableError => e
+          raise if e.tap.installed?
+
+          e.tap.clear_cache
+          safe_system "brew", "tap", e.tap.name
+          retry
+        end
+        formula_recursive_dependencies.each do |dependency|
+          conflicts += dependency.to_formula.conflicts.map do |c|
+            Formulary.factory(c.name)
+          end.select(&:any_version_installed?)
+        end
+        conflicts.each do |conflict|
+          test "brew", "unlink", conflict.name
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted from https://github.com/Homebrew/homebrew-test-bot/pull/582

This further splits the current `--only-formulae` step into `--only-formulae`, `--only-formulae-detect` and `--only-formulae-dependents`.

This will allow the failures to be more obvious on whether they are due to the changed formulae failing, the dependents of these formulae (or the detection of the changed formulae). It also generally further splits up a large, hugely complex class.

This will enable future PR work which should provide a few benefits:
- splitting out the detection, changed formulae and dependent formulae into separate steps
- not attempting to build any dependents if any changed formulae fail
- in future potentially cache the changed formulae bottles to avoid rebuilding them every time if they were built successfully last time (speeding up large PR rebuilds)
- in future potentially parallelising the dependent testing across multiple jobs/runners

`--only-formulae` should have the same results it has always done after this PR is merged. The ordering will change, though. 

If we're testing A and B which have dependents A->X and B->Y then the previous testing order was A,X,B,Y but will now be A,B,X,Y.