### PR TITLE
Add more arguments

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -22,6 +22,8 @@ module Homebrew
              description: "Don't check if the local system is set up correctly."
       switch "--build-from-source",
              description: "Build from source rather than building bottles."
+      switch "--build-dependents-from-source",
+             description: "Build dependents from source rather than testing bottles."
       switch "--junit",
              description: "generate a JUnit XML test results file."
       switch "--keep-old",
@@ -49,6 +51,8 @@ module Homebrew
              description: "Set the Git author/committer email to the given email."
       switch "--publish",
              description: "Publish the uploaded bottles."
+      switch "--skip-dependents",
+             description: "Don't test any dependents."
       switch "--skip-recursive-dependents",
              description: "Only test the direct dependents."
       switch "--only-cleanup-before",
@@ -65,9 +69,20 @@ module Homebrew
              description: "Only run the formulae dependents steps."
       switch "--only-cleanup-after",
              description: "Only run the post-cleanup step. Needs `--cleanup`."
+      flag   "--testing-formulae=",
+             description: "Use these testing formulae rather than running the formulae detection steps."
+      flag   "--added-formulae=",
+             description: "Use these added formulae rather than running the formulae detection steps."
+      flag   "--deleted-formulae=",
+             description: "Use these deleted formulae rather than running the formulae detection steps."
+      flag   "--skipped-or-failed-formulae=",
+             depends_on:  "--only-formulae-dependents",
+             description: "Use these skipped or failed formulae from formulae steps for a formulae dependents step."
       conflicts "--only-cleanup-before", "--only-setup", "--only-tap-syntax",
-                "--only-formulae", "--only-formulae-detect",
+                "--only-formulae", "--only-formulae-detect", "--only-formulae-dependents",
                 "--only-cleanup-after"
+      conflicts "--only-formulae-detect", "--testing-formulae", "--added-formulae", "--deleted-formulae"
+      conflicts "--skip-dependents", "--only-formulae-dependents"
     end
   end
 

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -109,7 +109,7 @@ module Homebrew
       end
 
       if tap
-        tap_github = " #{ENV["GITHUB_REPOSITORY"]}"
+        tap_github = " (#{ENV["GITHUB_REPOSITORY"]}" if tap.full_name != ENV["GITHUB_REPOSITORY"]
         tap_revision = Utils.safe_popen_read(
           GIT, "-C", tap.path.to_s,
           "log", "-1", "--format=%h (%s)"

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -41,7 +41,7 @@ module Homebrew
         unsatisfied_requirements, = fi.expand_requirements
         return if unsatisfied_requirements.blank?
 
-        unsatisfied_requirements.values.flatten.map(&:message).presence
+        unsatisfied_requirements.values.flatten.map(&:message).join("\n").presence
       end
 
       def cleanup_during!(args:)

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -15,9 +15,14 @@ module Homebrew
         sorted_formulae.each do |f|
           formula!(f, args: args)
         end
+
         @deleted_formulae.each do |f|
           deleted_formula!(f)
         end
+
+        return unless ENV["GITHUB_ACTIONS"]
+
+        puts "::set-output name=skipped_or_failed_formulae::#{@skipped_or_failed_formulae.join(",")}"
       end
 
       private

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -41,6 +41,7 @@ module Homebrew
         info_header "Determining dependents..."
 
         # Test reverse dependencies for linux-only formulae in linuxbrew-core.
+        # TODO: move this logic to a label
         if tap.present? &&
            tap.full_name == "Homebrew/linuxbrew-core" &&
            args.keep_old? &&
@@ -63,6 +64,7 @@ module Homebrew
           rust
         ]
 
+        # TODO: move this logic to a label
         if OS.linux? && tap.present? && tap.full_name == "Homebrew/homebrew-core"
           build_dependents_from_source_allowlist = []
         end
@@ -99,7 +101,9 @@ module Homebrew
           deps.any? do |d|
             full_name = d.to_formula.full_name
 
-            next false unless build_dependents_from_source_allowlist.include?(full_name)
+            if args.build_dependents_from_source? || build_dependents_from_source_allowlist.include?(full_name)
+              next false
+            end
 
             @testing_formulae.include?(full_name)
           end

--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -15,6 +15,12 @@ module Homebrew
 
       def run!(args:)
         detect_formulae!(args: args)
+
+        return unless ENV["GITHUB_ACTIONS"]
+
+        puts "::set-output name=testing_formulae::#{@testing_formulae.join(",")}"
+        puts "::set-output name=added_formulae::#{@added_formulae.join(",")}"
+        puts "::set-output name=deleted_formulae::#{@deleted_formulae.join(",")}"
       end
 
       private


### PR DESCRIPTION
Add more switches and flags to customise `brew test-bot` behaviour.

These will be used to move more logic from `brew test-bot` into labels in the Homebrew/homebrew-core workflow and separate formulae detection, build and dependants testing.

While we're here, also cleanup some ugly output that I noticed.