### PR TITLE
lib/test_runner: fix args.*_formulae handling.

### DIFF
--- a/lib/junit.rb
+++ b/lib/junit.rb
@@ -20,6 +20,8 @@ module Homebrew
       testsuites = @xml_document.add_element "testsuites"
 
       @tests.each do |test|
+        next if test.steps.empty?
+
         testsuite = testsuites.add_element "testsuite"
         testsuite.add_attribute "name", "brew-test-bot.#{Utils::Bottles.tag}"
         testsuite.add_attribute "timestamp", test.steps.first.start_time.iso8601

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -106,9 +106,9 @@ module Homebrew
                                                   verbose:   args.verbose?)
       end
 
-      no_formulae_flags = (args.testing_formulae.to_s.split(",") +
-                           args.added_formulae.to_s.split(",") +
-                           args.deleted_formulae.to_s.split(",")).blank?
+      no_formulae_flags = args.testing_formulae.nil? &&
+                          args.added_formulae.nil? &&
+                          args.deleted_formulae.nil?
       if no_formulae_flags && (no_only_args || args.only_formulae? || args.only_formulae_detect?)
         tests[:formulae_detect] = Tests::FormulaeDetect.new(argument, tap:       tap,
                                                                       git:       git,


### PR DESCRIPTION
When these are passed but with empty values we want to skip `formulae_detect`.

While we're here, also fix an exception with `lib/junit`.