### PR TITLE
lib/tests/formulae: fix install_gcc_if_needed.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -50,7 +50,7 @@ module Homebrew
             DevelopmentTools.clear_version_cache
             retry
           end
-          skipped formula_name, e.message
+          skipped formula.name, e.message
         end
       end
 


### PR DESCRIPTION
Use correct formula name variable when skipping.