### PR TITLE
formulae_dependents: fix dependent partitioning

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -82,7 +82,7 @@ module Homebrew
           deps.any? do |d|
             full_name = d.to_formula.full_name
 
-            next false if args.build_dependents_from_source? && !build_dependents_from_source_disabled
+            next false if !args.build_dependents_from_source? || build_dependents_from_source_disabled
 
             @testing_formulae.include?(full_name)
           end


### PR DESCRIPTION
When partitioning dependents into build-from-source dependents versus other dependents, we earlier used to:
```
next false unless build_dependents_from_source_allowlist.include?(full_name)
```
This was modified to:
```
next false if args.build_dependents_from_source? && !build_dependents_from_source_disabled
```
However this is an incorrect conversion from `unless` to `if`, we must return early with `false` unless the dependent is to be built from source, which means `if !args.build_dependents_from_source`. Also we should use OR to check if building dependents from source is disabled (for Linux).