### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,15 +52,30 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: docker build -t brew .
 
-      - name: Run brew test-bot --only-formulae --test-default-formula
+      - run: brew test-bot --only-formulae-detect --test-default-formula
+        id: formulae-detect
+
+      - name: Run brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
+        id: brew-test-bot-formulae
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             docker run \
               -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
               --rm brew \
-              brew test-bot --only-formulae --test-default-formula
+              brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
           else
-            brew test-bot --only-formulae --test-default-formula
+            brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
+          fi
+
+      - name: Run brew test-bot --only-formulae-dependents --junit --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            docker run \
+              -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
+              --rm brew \
+              brew test-bot --only-formulae-dependents --junit --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}}
+          else
+            brew test-bot --only-formulae-dependents --junit --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
           fi
 
       - name: Output brew test-bot failures

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage/
+vendor/
 bottle_output.txt
 brew-test-bot.xml
 steps_output.txt

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -178,8 +178,7 @@ module Homebrew
         filename = bottle_json.dig(formula.full_name, "bottle", "tags").values.first["filename"]
 
         download_strategy = CurlDownloadStrategy.new("#{root_url}/#{filename}", formula.name, formula.version)
-
-        HOMEBREW_CACHE.mkpath
+        download_strategy.cached_location.parent.mkpath
         FileUtils.ln @bottle_filename, download_strategy.cached_location, force: true
         FileUtils.ln_s download_strategy.cached_location.relative_path_from(download_strategy.symlink_location),
                        download_strategy.symlink_location,


### PR DESCRIPTION
- cleanup `.github/workflows/tests.yml` to more closely resemble homebrew/core (the place we care the most about testing and not breaking)
- ignore `vendor` from Git (and therefore VS Code)
- try to fix #646 by creating a fuller path