### PR TITLE
Dockerfile: use copy instead of add

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM homebrew/ubuntu16.04:master
 
-ADD . /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-test-bot
+COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-test-bot


### PR DESCRIPTION
Based on dawidd6's recommendation
Fixes:
error: could not lock config file .git/config: Permission denied
Error: Command failed with exit 255: git