### PR TITLE
formulae: don't skip testing new formulae on Linux

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -235,11 +235,6 @@ module Homebrew
            tap.present? &&
            tap.full_name == "Homebrew/homebrew-core"
 
-          if new_formula
-            skipped formula_name, "New formula are (currently) skipped on Linux!"
-            return
-          end
-
           if formula.bottle_specification.tag?(:all)
             skipped formula_name, "all: bottles are (currently) skipped on Linux!"
             return


### PR DESCRIPTION
As discussed on Slack, we already have a big chunk of formulae bottled for Linux in homebrew-core. Let's enable Linux CI for new formulae.