### PR TITLE
formula_dependents: ensure dependencies are linked

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -169,8 +169,19 @@ module Homebrew
         test "brew", "linkage", "--test", dependent.full_name
 
         if testable_dependents.include? dependent
-          test "brew", "install", "--only-dependencies", "--include-test",
-               dependent.full_name
+          test "brew", "install", "--only-dependencies", "--include-test", dependent.full_name
+
+          dependent.deps.each do |dependency|
+            next if dependency.build?
+
+            dependency_f = dependency.to_formula
+            next if dependency_f.keg_only?
+            next if dependency_f.linked_keg.exist?
+
+            unlink_conflicts dependency_f
+            test "brew", "link", dependency_f.full_name
+          end
+
           test "brew", "test", "--retry", "--verbose", dependent.full_name
         end
 


### PR DESCRIPTION
This PR ensures that we have all dependencies (runtime and test) linked while we test a formula.

Here's an original issue:
- Let's say we have 3 formulae in a test run `A`, `B` and `C`: `A` conflicts with `B`; `C` depends on `B`
- We unlink `B` while testing `A` (as a conflicting one)
- When we test `C`, `B` is still unlinked, and this could lead to a test failure for `C`

We got exactly this situation in 
- https://github.com/Homebrew/homebrew-core/pull/83573#issuecomment-902419098
- https://github.com/Homebrew/homebrew-core/pull/68089#issuecomment-757338842
- https://github.com/Homebrew/homebrew-core/pull/67615#issuecomment-751294621

Fixes https://github.com/Homebrew/homebrew-test-bot/issues/544

\cc @carlocab @scpeters 