### PR TITLE
lib/test_bot: set `HOMEBREW_FORCE_BREWED_CURL` on Mojave

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -61,6 +61,10 @@ module Homebrew
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
 
+      # Temporary workaround for https://github.com/Homebrew/brew/issues/12161
+      # TODO: Remove me when there is a better fix.
+      ENV["HOMEBREW_FORCE_BREWED_CURL"] = "1" if OS.mac? && MacOS.version <= :mojave
+
       if args.local?
         ENV["HOMEBREW_HOME"] = ENV["HOME"] = "#{Dir.pwd}/home"
         ENV["HOMEBREW_LOGS"] = "#{Dir.pwd}/logs"


### PR DESCRIPTION
Mojave Curl currently doesn't work (cf. Homebrew/brew#12161). Until we
have a fix in `brew`, let's set this in `test-bot` so that we can get CI
in Homebrew/core running again.