### PR TITLE
Revert "lib/test_bot: set `HOMEBREW_FORCE_BREWED_CURL` on Mojave"

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -61,10 +61,6 @@ module Homebrew
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
 
-      # Temporary workaround for https://github.com/Homebrew/brew/issues/12161
-      # TODO: Remove me when there is a better fix.
-      ENV["HOMEBREW_FORCE_BREWED_CURL"] = "1" if OS.mac? && MacOS.version <= :mojave
-
       if args.local?
         ENV["HOMEBREW_HOME"] = ENV["HOME"] = "#{Dir.pwd}/home"
         ENV["HOMEBREW_LOGS"] = "#{Dir.pwd}/logs"


### PR DESCRIPTION
Reverts Homebrew/homebrew-test-bot#668

We won't need this soon, and is going to be blocking our effort to ship any revision bumps to Curl dependencies.