### PR TITLE
lib/test_bot: set `HOMEBREW_FORCE_BREWED_CA_CERTIFICATES` on Mojave

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -62,6 +62,9 @@ module Homebrew
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
 
+      # https://github.com/Homebrew/brew/pull/12167
+      ENV["HOMEBREW_FORCE_BREWED_CA_CERTIFICATES"] = "1" if OS.mac? && MacOS.version <= :mojave
+
       if args.local?
         ENV["HOMEBREW_HOME"] = ENV["HOME"] = "#{Dir.pwd}/home"
         ENV["HOMEBREW_LOGS"] = "#{Dir.pwd}/logs"


### PR DESCRIPTION
CI still isn't installing `ca-certificates` despite
b2b7bb0da889246e89c8ba06846e3c4e8bc19279. See
Homebrew/homebrew-core#86423.

----

I'll admit to not being sure why this is needed, as this should already be set given Homebrew/brew#12167.