### PR TITLE
lib/tests/formulae: cleanup

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -62,9 +62,6 @@ module Homebrew
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"
 
-      # https://github.com/Homebrew/brew/pull/12167
-      ENV["HOMEBREW_FORCE_BREWED_CA_CERTIFICATES"] = "1" if OS.mac? && MacOS.version <= :mojave
-
       if args.local?
         ENV["HOMEBREW_HOME"] = ENV["HOME"] = "#{Dir.pwd}/home"
         ENV["HOMEBREW_LOGS"] = "#{Dir.pwd}/logs"

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -38,7 +38,7 @@ module Homebrew
       end
 
       def install_ca_certificates_if_needed
-        return if ENV["HOMEBREW_FORCE_BREWED_CA_CERTIFICATES"].blank?
+        return if DevelopmentTools.ca_file_handles_most_https_certificates?
 
         test "brew", "install", "ca-certificates",
              env: { "HOMEBREW_DEVELOPER" => nil }


### PR DESCRIPTION
Let's use `DevelopmentTools.ca_file_handles_most_https_certificates?` to
avoid having to set `HOMEBREW_FORCE_BREWED_CA_CERTIFICATES` for
ourselves in `test-bot`.