### PR TITLE
lib/tests/formulae: stop skipping `all` bottles on Linux

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -239,13 +239,13 @@ module Homebrew
 
         if OS.linux? &&
            args.skip_unbottled_linux? &&
+           !formula.bottled? &&
+           !formula.bottle_unneeded? &&
+           !new_formula &&
            tap.present? &&
            tap.full_name == "Homebrew/homebrew-core"
-
-          if !formula.bottled? && !formula.bottle_unneeded? && !new_formula
-            skipped formula_name, "#{formula.full_name} has not (yet) been bottled on Linux!"
-            return
-          end
+          skipped formula_name, "#{formula.full_name} has not (yet) been bottled on Linux!"
+          return
         end
 
         deps = []


### PR DESCRIPTION
I think it's time we started testing these formulae properly, especially
since I know of a few that have `all` bottles that were built on Linux
too.

We also want to do this before migrating users to Homebrew/core. We
don't want Linux users who are migrated to start installing `all`
bottles that don't actually work.