### PR TITLE
lib/tests/formulae_dependents: skip unbottled source builds

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -29,12 +29,18 @@ module Homebrew
           dependents_for_formula(formula, formula_name, args: args)
 
         source_dependents.each do |dependent|
-          install_dependent(dependent, testable_dependents, build_from_source: true, args: args)
-
           bottled = with_env(HOMEBREW_SKIP_OR_LATER_BOTTLES: "1") do
             dependent.bottled?
           end
-          install_dependent(dependent, testable_dependents, args: args) if bottled
+
+          # TODO: A better thing to do here would be to attempt a source build
+          #       of unbottled dependents, but reverse the failure condition; i.e.
+          #       a successful source build is a failure, but a failed source build
+          #       is a pass to enable detection of unbottled formulae that should be bottled.
+          next unless bottled
+
+          install_dependent(dependent, testable_dependents, build_from_source: true, args: args)
+          install_dependent(dependent, testable_dependents, args: args)
         end
 
         bottled_dependents.each do |dependent|


### PR DESCRIPTION
We regularly see CI failures from attempted source builds of dependents
that aren't bottled (cf. any Go, Rust, or GHC PR). Let's avoid these by
not attempting these builds at all.

However, in the longer term, I believe it would be good to attempt these
source builds but reverse the failure condition: a build/test failure is
expected, so the test should pass when this happens, and fail when it
doesn't.

That would allow us to detect unbottled dependents that should be
bottled.

That change will take some work, however, so I've left a `TODO` in a
comment that I intend to revisit at some point.