### PR TITLE
Implement check for bottleable formulae dependents

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -9,7 +9,7 @@ module Homebrew
     # Instantiates a Step object.
     # @param command [Array<String>] Command to execute and arguments.
     # @param env [Hash] Environment variables to set when running command.
-    def initialize(command, env:, verbose:, expect_error:, multistage:)
+    def initialize(command, env:, verbose:, expect_error: false, multistage: false)
       @command = command
       @env = env
       @verbose = verbose

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -28,6 +28,22 @@ module Homebrew
       end
     end
 
+    def pending_steps
+      steps.select(&:pending?)
+    end
+
+    def resolve_pending(passed: nil)
+      return unless pending_steps.present?
+
+      info_header "Determining status of pending tests..."
+
+      @steps.select(&:pending?).each do |s|
+        s.resolve_pending(passed: passed)
+      end
+
+      exit 1 if @fail_fast && @steps.any?(&:failed?)
+    end
+
     def test_header(klass, method: "run!")
       puts
       puts Formatter.headline("Running #{klass}##{method}", color: :magenta)
@@ -37,8 +53,8 @@ module Homebrew
       puts Formatter.headline(text, color: :cyan)
     end
 
-    def test(*arguments, env: {}, verbose: @verbose)
-      step = Step.new(arguments, env: env, verbose: verbose)
+    def test(*arguments, env: {}, verbose: @verbose, expect_error: false, multistage: false)
+      step = Step.new(arguments, env: env, verbose: verbose, expect_error: expect_error, multistage: multistage)
       step.run(dry_run: @dry_run, fail_fast: @fail_fast)
       @steps << step
       step

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -33,7 +33,7 @@ module Homebrew
     end
 
     def resolve_pending(passed: nil)
-      return unless pending_steps.present?
+      return if pending_steps.blank?
 
       info_header "Determining status of pending tests..."
 

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -36,8 +36,8 @@ module Homebrew
           install_dependent(
             dependent,
             testable_dependents,
-            build_from_source: true,
-            args: args,
+            build_from_source:        true,
+            args:                     args,
             check_for_missing_bottle: !bottled
           )
 
@@ -183,7 +183,11 @@ module Homebrew
                env: no_dev_env, expect_error: check_for_missing_bottle, multistage: check_for_missing_bottle
           return if steps.last.failed?
         end
-        return unless dependent.latest_version_installed?
+
+        unless dependent.latest_version_installed?
+          resolve_pending(passed: true) if check_for_missing_bottle
+          return
+        end
 
         if !dependent.keg_only? && !dependent.linked_keg.exist?
           unlink_conflicts dependent

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -38,7 +38,7 @@ module Homebrew
             testable_dependents,
             build_from_source:        true,
             args:                     args,
-            check_for_missing_bottle: !bottled
+            check_for_missing_bottle: !bottled,
           )
 
           install_dependent(dependent, testable_dependents, args: args) if bottled


### PR DESCRIPTION
This implements my idea from #677.

Let's reinstate attempting to build unbottled dependents from source
when they are in the `source_dependents` array, but expect at least one
of `brew install --only-dependencies`, `brew install --build-from-source`,
`brew linkage --test`, or `brew test` to produce an error.

This is a little more complicated than I'd like, because this actually
required implementing two distinct orthogonal features:
- creating `Step`s that are expected to produce an error
- delaying the classification of steps as `:passed` or `:failed`
  depending on the status of other steps