### PR TITLE
lib/tests/formulae: skip unbottled formulae on Monterey

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -228,6 +228,13 @@ module Homebrew
         end
         new_formula = @added_formulae.include?(formula_name)
 
+        if MacOS.version == :monterey &&
+           !formula.bottled? &&
+           !formula.bottle_unneeded?
+          skipped formula_name, "#{formula.full_name} has not yet been bottled on Monterey!"
+          return
+        end
+
         if Hardware::CPU.arm? &&
            args.skip_unbottled_arm? &&
            !formula.bottled? &&


### PR DESCRIPTION
This will allow us to enable Monterey CI in PRs without worrying about
accidentally bottling something whose dependencies have yet to be
bottled.

This is useful for PRs for formulae that already have Monterey bottles
(e.g. Homebrew/homebrew-core#87862).

Pair with Homebrew/homebrew-core#87871.