### PR TITLE
lib/tests/formulae: install curl if resources use Homebrew curl

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -45,7 +45,7 @@ module Homebrew
       end
 
       def downloads_using_homebrew_curl?(formula)
-        %i[stable head].any? do |spec_name|
+        [:stable, :head].any? do |spec_name|
           next false unless (spec = formula.send(spec_name))
 
           spec.using == :homebrew_curl || spec.resources.values.any? { |r| r.using == :homebrew_curl }

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -44,18 +44,19 @@ module Homebrew
              env: { "HOMEBREW_DEVELOPER" => nil }
       end
 
-      def install_curl_if_needed(formula)
-        %w[Stable HEAD].each do |name|
-          spec_name = name.downcase.to_sym
-          next unless (spec = formula.send(spec_name))
+      def downloads_using_homebrew_curl?(formula)
+        %i[stable head].any? do |spec_name|
+          next false unless (spec = formula.send(spec_name))
 
-          next if spec.using != :homebrew_curl && ENV["HOMEBREW_FORCE_BREWED_CURL"].blank?
-
-          test "brew", "install", "curl",
-               env: { "HOMEBREW_DEVELOPER" => nil }
-
-          break
+          spec.using == :homebrew_curl || spec.resources.values.any? { |r| r.using == :homebrew_curl }
         end
+      end
+
+      def install_curl_if_needed(formula)
+        return unless downloads_using_homebrew_curl?(formula)
+
+        test "brew", "install", "curl",
+             env: { "HOMEBREW_DEVELOPER" => nil }
       end
 
       def install_gcc_if_needed(formula, deps)


### PR DESCRIPTION
`install_curl_if_needed` will not install `curl` if a formula declares
`using: :homebrew_curl` for a resource. Let's change that by checking
the resources for `using: :homebrew_curl` too.

Needed for Homebrew/homebrew-core#88330.
