### PR TITLE
lib/tests/formulae: remove ARM/Linux skip behaviour

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -227,6 +227,15 @@ module Homebrew
           skipped formula_name, "#{formula.full_name} has been disabled!"
           return
         end
+
+        all_deps_have_compatible_bottles = formula.deps.all? do |dep|
+          dep.to_formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: false)
+        end
+        unless all_deps_have_compatible_bottles
+          skipped formula_name, "#{formula_name} has dependencies without a compatible bottle!"
+          return
+        end
+
         new_formula = @added_formulae.include?(formula_name)
         bottled_on_current_version = formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: true)
 

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -217,9 +217,13 @@ module Homebrew
         test "brew", "install", @bottle_filename
       end
 
+      def bottled?(formula, no_older_versions:)
+        formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: no_older_versions)
+      end
+
       def build_bottle?(formula, args:)
         all_deps_bottled = formula.deps.all? do |dep|
-          dep.to_formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: true)
+          bottled?(dep.to_formula, no_older_versions: true)
         end
 
         all_deps_bottled && !formula.bottle_disabled? && !args.build_from_source?
@@ -237,7 +241,7 @@ module Homebrew
         end
 
         all_deps_have_compatible_bottles = formula.deps.all? do |dep|
-          dep.to_formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: false)
+          bottled?(dep.to_formula, no_older_versions: false)
         end
         unless all_deps_have_compatible_bottles
           skipped formula_name, "#{formula_name} has dependencies without a compatible bottle!"
@@ -245,7 +249,7 @@ module Homebrew
         end
 
         new_formula = @added_formulae.include?(formula_name)
-        bottled_on_current_version = formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: true)
+        bottled_on_current_version = bottled?(formula, no_older_versions: true)
 
         deps = []
         reqs = []


### PR DESCRIPTION
The current system requires too much manual intervention before a
formula is bottled. While bottling for Monterey, I discovered about two
dozen formulae that should have had ARM Big Sur bottles but didn't.
Presumably, I would have found more if I were trying to look.

Let's try to automate more of the bottling process by always attempting
a build on ARM and Linux. We avoid CI failures by using `skipped`
instead of `failed` whenever we encounter a build/test/linkage error on
a formula that hasn't been bottled for the current OS.
