### PR TITLE
lib/test_bot: dont pass --full flag to brew tap command

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -76,7 +76,7 @@ module Homebrew
       # bottle rebuild and bottle upload rely on full clone.
       if tap
         if !tap.path.exist?
-          safe_system "brew", "tap", tap.name, "--full"
+          safe_system "brew", "tap", tap.name
         elsif (tap.path/".git/shallow").exist?
           raise unless quiet_system GIT, "-C", tap.path, "fetch", "--unshallow"
         end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-test-bot/issues/688

The command `brew tap` no longer supports the flag `--full`, causes the error 

```
Calling `brew tap --full` is disabled! There is no replacement.
```