### PR TITLE
Ignore failures from unbottled formulae

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -59,6 +59,8 @@ module Homebrew
     end
 
     def ignore
+      return if passed?
+
       @status = :ignored
     end
 

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -54,6 +54,10 @@ module Homebrew
       @status == :failed
     end
 
+    def ignored?
+      @status == :ignored
+    end
+
     def ignore
       @status = :ignored
     end

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -54,6 +54,10 @@ module Homebrew
       @status == :failed
     end
 
+    def ignore
+      @status = :ignored
+    end
+
     def puts_command
       puts Formatter.headline(command_trimmed, color: :blue)
     end

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -6,6 +6,10 @@ module Homebrew
       @steps.select(&:failed?)
     end
 
+    def ignored_steps
+      @steps.select(&:ignored?)
+    end
+
     attr_reader :steps
 
     private

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -13,6 +13,10 @@ module Homebrew
 
       protected
 
+      def bottled?(formula, no_older_versions:)
+        formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: no_older_versions)
+      end
+
       def skipped(formula_name, reason)
         @skipped_or_failed_formulae << formula_name
 

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -53,12 +53,25 @@ module Homebrew
       failed_steps = tests.map(&:failed_steps)
                           .flatten
                           .compact
-      steps_output = if failed_steps.empty?
+      ignored_steps = tests.map(&:ignored_steps)
+                           .flatten
+                           .compact
+      steps_output = if failed_steps.empty? && ignored_steps.empty?
         "All steps passed!"
       else
-        failed_steps_output = ["Error: #{failed_steps.count} failed #{"step".pluralize(failed_steps.count)}!"]
-        failed_steps_output += failed_steps.map(&:command_trimmed)
-        failed_steps_output.join("\n")
+        output_lines = []
+
+        unless ignored_steps.empty?
+          output_lines += ["Warning: #{ignored_steps.count} failed #{"step".pluralize(ignored_steps.count)} ignored!"]
+          output_lines += ignored_steps.map(&:command_trimmed)
+        end
+
+        unless failed_steps.empty?
+          output_lines += ["Error: #{failed_steps.count} failed #{"step".pluralize(failed_steps.count)}!"]
+          output_lines += failed_steps.map(&:command_trimmed)
+        end
+
+        output_lines.join("\n")
       end
       puts steps_output
 

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -56,17 +56,17 @@ module Homebrew
       ignored_steps = tests.map(&:ignored_steps)
                            .flatten
                            .compact
-      steps_output = if failed_steps.empty? && ignored_steps.empty?
+      steps_output = if failed_steps.blank? && ignored_steps.blank?
         "All steps passed!"
       else
         output_lines = []
 
-        unless ignored_steps.empty?
+        if ignored_steps.present?
           output_lines += ["Warning: #{ignored_steps.count} failed #{"step".pluralize(ignored_steps.count)} ignored!"]
           output_lines += ignored_steps.map(&:command_trimmed)
         end
 
-        unless failed_steps.empty?
+        if failed_steps.present?
           output_lines += ["Error: #{failed_steps.count} failed #{"step".pluralize(failed_steps.count)}!"]
           output_lines += failed_steps.map(&:command_trimmed)
         end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -217,10 +217,6 @@ module Homebrew
         test "brew", "install", @bottle_filename
       end
 
-      def bottled?(formula, no_older_versions:)
-        formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: no_older_versions)
-      end
-
       def build_bottle?(formula, args:)
         all_deps_bottled = formula.deps.all? do |dep|
           bottled?(dep.to_formula, no_older_versions: true)

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -320,15 +320,16 @@ module Homebrew
         end
         test "brew", "install", *install_args,
              env: env.merge({ "HOMEBREW_DEVELOPER" => nil })
-        install_passed = steps.last.passed?
+        install_step = steps.last
 
         test "brew", "livecheck", *livecheck_args if formula.livecheckable? && !formula.livecheck.skip?
 
         test "brew", "audit", *audit_args unless formula.deprecated?
-        unless install_passed
+        unless install_step.passed?
           if bottled_on_current_version
             failed formula_name, "install failed"
           else
+            install_step.ignore
             skipped formula_name, "install failed"
           end
           return
@@ -336,8 +337,9 @@ module Homebrew
 
         bottle_reinstall_formula(formula, new_formula, args: args)
         test "brew", "linkage", "--test", formula_name
+        linkage_step = steps.last
         failed_linkage_or_test_messages ||= []
-        failed_linkage_or_test_messages << "linkage failed" if steps.last.failed?
+        failed_linkage_or_test_messages << "linkage failed" if linkage_step.failed?
 
         test "brew", "install", "--only-dependencies", "--include-test", formula_name
 
@@ -350,7 +352,8 @@ module Homebrew
           # Intentionally not passing --retry here to avoid papering over
           # flaky tests when a formula isn't being pulled in as a dependent.
           test "brew", "test", "--verbose", formula_name, env: env
-          failed_linkage_or_test_messages << "test failed" if steps.last.failed?
+          test_step = steps.last
+          failed_linkage_or_test_messages << "test failed" if test_step.failed?
         end
 
         # Move bottle and don't test dependents if the formula linkage or test failed.
@@ -364,6 +367,8 @@ module Homebrew
           if bottled_on_current_version
             failed formula_name, failed_linkage_or_test_messages.join(", ")
           else
+            linkage_step.ignore if linkage_step.failed?
+            test_step.ignore if test_step&.failed?
             skipped formula_name, failed_linkage_or_test_messages.join(", ")
           end
         end


### PR DESCRIPTION
This completes #687. It's not enough to call `skipped` because some
steps will still have a `:failed` status, and that will cause `test-bot`
to exit with an error.
