### PR TITLE
lib/tests/formulae: tweak skipping formulae with unbottled deps

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -243,13 +243,14 @@ module Homebrew
         all_deps_have_compatible_bottles = formula.deps.all? do |dep|
           bottled?(dep.to_formula, no_older_versions: false)
         end
-        unless all_deps_have_compatible_bottles
+        bottled_on_current_version = bottled?(formula, no_older_versions: true)
+
+        if !all_deps_have_compatible_bottles && !bottled_on_current_version
           skipped formula_name, "#{formula_name} has dependencies without a compatible bottle!"
           return
         end
 
         new_formula = @added_formulae.include?(formula_name)
-        bottled_on_current_version = bottled?(formula, no_older_versions: true)
 
         deps = []
         reqs = []


### PR DESCRIPTION
There is a corner case where an unbottled dependency is added to a
bottled formula. The current behaviour would silently skip the build,
which is undesirable. Let's retain the old behaviour for this case,
which is to attempt the build anyway (and most likely fail).

I'm not certain this is the correct behaviour yet, but the old one is,
in my opinion, still better than what is happening now.

See Homebrew/homebrew-core#88797.
