### PR TITLE
lib/tests/formulae: relax test dep requirements when building bottles

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -222,14 +222,10 @@ module Homebrew
       end
 
       def build_bottle?(formula, args:)
-        # Require build and runtime dependencies to be bottled on the current OS.
-        return false unless formula.deps.reject(&:test?).all? do |dep|
-          bottled?(dep.to_formula, no_older_versions: true)
-        end
-
-        # Accept an older compatible bottle for test dependencies.
-        return false unless formula.deps.select(&:test?).all? do |dep|
-          bottled?(dep.to_formula, no_older_versions: false)
+        # Build and runtime dependencies must be bottled on the current OS,
+        # but accept an older compatible bottle for test dependencies.
+        return false if formula.deps.any? do |dep|
+          !bottled?(dep.to_formula, no_older_versions: !dep.test?)
         end
 
         !formula.bottle_disabled? && !args.build_from_source?

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -222,11 +222,17 @@ module Homebrew
       end
 
       def build_bottle?(formula, args:)
-        all_deps_bottled = formula.deps.all? do |dep|
+        # Require build and runtime dependencies to be bottled on the current OS.
+        return false unless formula.deps.reject(&:test?).all? do |dep|
           bottled?(dep.to_formula, no_older_versions: true)
         end
 
-        all_deps_bottled && !formula.bottle_disabled? && !args.build_from_source?
+        # Accept an older compatible bottle for test dependencies.
+        return false unless formula.deps.select(&:test?).all? do |dep|
+          bottled?(dep.to_formula, no_older_versions: false)
+        end
+
+        !formula.bottle_disabled? && !args.build_from_source?
       end
 
       def formula!(formula_name, args:)


### PR DESCRIPTION
Test-only dependencies have no impact on the bottle that is built, so
there is no need to check that these dependencies are bottled on the
current OS before a formula is bottled.

Let's relax the requirement that a test dependency is bottled for the
current OS to a check that a test dependency has a usable bottle. At
worst, the older bottle doesn't work and the test will fail. If it does
work, there's no reason for this dependency to block bottling.
