### PR TITLE
lib/test_formula: fix method signature

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -13,8 +13,8 @@ module Homebrew
 
       protected
 
-      def bottled?(formula, no_older_versions:)
-        formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: no_older_versions)
+      def bottled?(formula, tag = nil, no_older_versions: false)
+        formula.bottle_specification.tag?(Utils::Bottles.tag(tag), no_older_versions: no_older_versions)
       end
 
       def skipped(formula_name, reason)


### PR DESCRIPTION
This got misplaced while refactoring in #691.
