### PR TITLE
formulae_dependents: fix `bottled?` method call

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -143,7 +143,7 @@ module Homebrew
         cleanup_during!(args: args)
 
         required_dependent_deps = dependent.deps.reject(&:optional?)
-        bottled_on_current_version = bottled?(formula, no_older_versions: true)
+        bottled_on_current_version = bottled?(dependent, no_older_versions: true)
 
         unless dependent.latest_version_installed?
           build_args = []


### PR DESCRIPTION
There is no variable called `formula` in this method, so we should refer
to `dependent` instead.
