### PR TITLE
Add a `--skip-online-checks` flag

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -51,6 +51,8 @@ module Homebrew
              description: "Set the Git author/committer email to the given email."
       switch "--publish",
              description: "Publish the uploaded bottles."
+      switch "--skip-online-checks",
+             description: "Don't pass `--online` to `brew audit` and skip `brew livecheck`."
       switch "--skip-dependents",
              description: "Don't test any dependents."
       switch "--skip-recursive-dependents",

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -267,7 +267,8 @@ module Homebrew
         livecheck_args << "--full-name"
         livecheck_args << "--debug"
 
-        audit_args = [formula_name, "--online"]
+        audit_args = [formula_name]
+        audit_args << "--online" unless args.skip_online_checks?
         if new_formula
           audit_args << "--new-formula"
         else
@@ -321,7 +322,9 @@ module Homebrew
              env: env.merge({ "HOMEBREW_DEVELOPER" => nil })
         install_step = steps.last
 
-        test "brew", "livecheck", *livecheck_args if formula.livecheckable? && !formula.livecheck.skip?
+        if formula.livecheckable? && !formula.livecheck.skip? && !args.skip_online_checks?
+          test "brew", "livecheck", *livecheck_args
+        end
 
         test "brew", "audit", *audit_args unless formula.deprecated?
         unless install_step.passed?


### PR DESCRIPTION
Passing this flag to `test-bot` will omit the `--online` flag from
`brew audit`, and also skip `brew livecheck`.

This is useful for at least three cases:

1. Bottling on a new OS/architecture. These failures should probably not
   block this especially if the build/linkage/test and install audits
   succeeded.
2. Failures which seem to occur only in CI. (cf.
   Homebrew/homebrew-core#88329, Homebrew/homebrew-core#89042)
3. PRs which require revision bumps to multiple formulae. CI runs on
   these PRs often take a very long time, and this makes fixing these
   failures (which is sometimes not even possible) and then re-running
   CI very impractical.

The last point is a particularly sore pain point for me, because I find
few things more frustrating than waiting a long time for CI to run only
to find that dependent tests have been blocked because livecheck failed,
or because the audit failed because the stable tarball was not reachable
(despite the source build completing successfully).
