### PR TITLE
lib/tests/formulae: demote more unbottled failures to warnings

### DIFF
--- a/lib/test.rb
+++ b/lib/test.rb
@@ -32,6 +32,10 @@ module Homebrew
       end
     end
 
+    def warn(file, msg)
+      puts "::warning file=#{file}::#{msg}"
+    end
+
     def test_header(klass, method: "run!")
       puts
       puts Formatter.headline("Running #{klass}##{method}", color: :magenta)

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -33,6 +33,8 @@ module Homebrew
     end
 
     def warn(file, msg)
+      return if ENV["GITHUB_ACTIONS"].blank?
+
       puts "::warning file=#{file}::#{msg}"
     end
 

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -13,6 +13,14 @@ module Homebrew
 
       protected
 
+      def warn_formula_step_failure(formula, step)
+        formula = Formulary.factory(formula.to_s)
+        path = formula.path.delete_prefix("#{@repository}/")
+        arch = Hardware::CPU.arch
+        runner = OS.mac? ? "macOS #{MacOS.version}-#{arch}" : "#{arch}-#{OS.kernel_name}"
+        warn(path, "`#{step.command_short}` failed on #{runner}!")
+      end
+
       def bottled?(formula, tag = nil, no_older_versions: false)
         formula.bottle_specification.tag?(Utils::Bottles.tag(tag), no_older_versions: no_older_versions)
       end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -127,12 +127,25 @@ module Homebrew
         unless changed_dependencies.empty?
           test "brew", "fetch", "--retry", "--build-from-source",
                *changed_dependencies
+
+          unbottled_deps = changed_dependencies.any? do |dep|
+            !bottled?(Formulary.factory(dep), no_older_versions: true)
+          end
           # Install changed dependencies as new bottles so we don't have
-          # checksum problems.
+          # checksum problems. We have to install all `changed_dependencies`
+          # in one `brew install` command to make sure they are installed in
+          # the right order.
           test "brew", "install", "--build-from-source", *changed_dependencies
+          install_step = steps.last
           # Run postinstall on them because the tested formula might depend on
           # this step
           test "brew", "postinstall", *changed_dependencies
+          postinstall_step = steps.last
+
+          if unbottled_deps
+            install_step.ignore if install_step.failed?
+            postinstall_step.ignore if postinstall_step.failed?
+          end
         end
 
         runtime_or_test_dependencies =


### PR DESCRIPTION
Let's demote another class of CI failures from unbottled formulae to
warnings: attempting to build a formula with a dependency that is also
in the `@testing_formulae` array. We see this in Homebrew/homebrew-core#89193.

It would be nice to be able to restrict the failures we ignore to only
the unbottled ones, but we need to pass the `changed_dependencies` in
its entirety to `brew install` in order for `brew` to work out the
correct order to install these dependencies.
