### PR TITLE
Implement annotations for relevant errors

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -61,12 +61,6 @@ module Homebrew
       @status == :ignored
     end
 
-    def ignore
-      return if passed?
-
-      @status = :ignored
-    end
-
     def puts_command
       puts Formatter.headline(command_trimmed, color: :blue)
     end

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -11,7 +11,7 @@ module Homebrew
     # @param env [Hash] Environment variables to set when running command.
     def initialize(command, env:, verbose:, named_args: nil, ignore_failures: false, repository: nil)
       @named_args = [named_args].flatten.compact.map(&:to_s)
-      @command = command | @named_args
+      @command = command + @named_args
       @env = env
       @verbose = verbose
       @ignore_failures = ignore_failures

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -47,8 +47,15 @@ module Homebrew
       puts Formatter.headline(text, color: :cyan)
     end
 
-    def test(*arguments, env: {}, verbose: @verbose)
-      step = Step.new(arguments, env: env, verbose: verbose)
+    def test(*arguments, named_args: nil, env: {}, verbose: @verbose, ignore_failures: false)
+      step = Step.new(
+        arguments,
+        named_args:      named_args,
+        env:             env,
+        verbose:         verbose,
+        ignore_failures: ignore_failures,
+        repository:      @repository,
+      )
       step.run(dry_run: @dry_run, fail_fast: @fail_fast)
       @steps << step
       step

--- a/lib/test.rb
+++ b/lib/test.rb
@@ -32,12 +32,6 @@ module Homebrew
       end
     end
 
-    def warn(file, msg)
-      return if ENV["GITHUB_ACTIONS"].blank?
-
-      puts "::warning file=#{file}::#{msg}"
-    end
-
     def test_header(klass, method: "run!")
       puts
       puts Formatter.headline("Running #{klass}##{method}", color: :magenta)

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -13,14 +13,6 @@ module Homebrew
 
       protected
 
-      def warn_formula_step_failure(formula, step)
-        formula = Formulary.factory(formula.to_s)
-        path = formula.path.to_s.delete_prefix("#{@repository}/")
-        arch = Hardware::CPU.arch
-        runner = OS.mac? ? "macOS #{MacOS.version}-#{arch}" : "#{arch}-#{OS.kernel_name}"
-        warn(path, "`#{step.command_short}` failed on #{runner}!")
-      end
-
       def bottled?(formula, tag = nil, no_older_versions: false)
         formula.bottle_specification.tag?(Utils::Bottles.tag(tag), no_older_versions: no_older_versions)
       end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -137,7 +137,7 @@ module Homebrew
           # in one `brew install` command to make sure they are installed in
           # the right order.
           test "brew", "install", "--build-from-source",
-               named_args: changed_dependencies,
+               named_args:      changed_dependencies,
                ignore_failures: ignore_failures
           # Run postinstall on them because the tested formula might depend on
           # this step
@@ -328,8 +328,8 @@ module Homebrew
           d.name == "git" && (!d.test? || d.build?)
         end
         test "brew", "install", *install_args,
-             named_args: formula_name,
-             env: env.merge({ "HOMEBREW_DEVELOPER" => nil }),
+             named_args:      formula_name,
+             env:             env.merge({ "HOMEBREW_DEVELOPER" => nil }),
              ignore_failures: ignore_failures
         install_step = steps.last
 

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -128,36 +128,20 @@ module Homebrew
           test "brew", "fetch", "--retry", "--build-from-source",
                *changed_dependencies
 
+          ignore_failures = changed_dependencies.any? do |dep|
+            !bottled?(Formulary.factory(dep), no_older_versions: true)
+          end
+
           # Install changed dependencies as new bottles so we don't have
           # checksum problems. We have to install all `changed_dependencies`
           # in one `brew install` command to make sure they are installed in
           # the right order.
-          test "brew", "install", "--build-from-source", *changed_dependencies
-          install_step = steps.last
+          test "brew", "install", "--build-from-source",
+               named_args: changed_dependencies,
+               ignore_failures: ignore_failures
           # Run postinstall on them because the tested formula might depend on
           # this step
-          test "brew", "postinstall", *changed_dependencies
-          postinstall_step = steps.last
-
-          if changed_dependencies.any? do |dep|
-            !bottled?(Formulary.factory(dep), no_older_versions: true)
-          end
-            if install_step.failed?
-              install_step.ignore
-
-              changed_dependencies.each do |dep|
-                warn_formula_step_failure(dep, install_step)
-              end
-            end
-
-            if postinstall_step.failed?
-              postinstall_step.ignore
-
-              changed_dependencies.each do |dep|
-                warn_formula_step_failure(dep, postinstall_step)
-              end
-            end
-          end
+          test "brew", "postinstall", named_args: changed_dependencies, ignore_failures: ignore_failures
         end
 
         runtime_or_test_dependencies =
@@ -274,6 +258,7 @@ module Homebrew
         end
 
         new_formula = @added_formulae.include?(formula_name)
+        ignore_failures = !bottled_on_current_version && !new_formula
 
         deps = []
         reqs = []
@@ -328,10 +313,9 @@ module Homebrew
 
         install_args = ["--verbose"]
         install_args << build_flag
-        install_args << formula_name
 
         # Don't care about e.g. bottle failures for dependencies.
-        test "brew", "install", "--only-dependencies", *install_args,
+        test "brew", "install", "--only-dependencies", *install_args, formula_name,
              env: { "HOMEBREW_DEVELOPER" => nil }
 
         # Do this after installing dependencies to avoid skipping formulae
@@ -344,7 +328,9 @@ module Homebrew
           d.name == "git" && (!d.test? || d.build?)
         end
         test "brew", "install", *install_args,
-             env: env.merge({ "HOMEBREW_DEVELOPER" => nil })
+             named_args: formula_name,
+             env: env.merge({ "HOMEBREW_DEVELOPER" => nil }),
+             ignore_failures: ignore_failures
         install_step = steps.last
 
         if formula.livecheckable? && !formula.livecheck.skip? && !args.skip_online_checks?
@@ -353,20 +339,19 @@ module Homebrew
 
         test "brew", "audit", *audit_args unless formula.deprecated?
         unless install_step.passed?
-          if bottled_on_current_version || new_formula
-            failed formula_name, "install failed"
-          else
-            install_step.ignore
+          if ignore_failures
             skipped formula_name, "install failed"
+          else
+            failed formula_name, "install failed"
           end
+
           return
         end
 
         bottle_reinstall_formula(formula, new_formula, args: args)
-        test "brew", "linkage", "--test", formula_name
-        linkage_step = steps.last
+        test "brew", "linkage", "--test", named_args: formula_name, ignore_failures: ignore_failures
         failed_linkage_or_test_messages ||= []
-        failed_linkage_or_test_messages << "linkage failed" if linkage_step.failed?
+        failed_linkage_or_test_messages << "linkage failed" unless steps.last.passed?
 
         test "brew", "install", "--only-dependencies", "--include-test", formula_name
 
@@ -378,9 +363,8 @@ module Homebrew
 
           # Intentionally not passing --retry here to avoid papering over
           # flaky tests when a formula isn't being pulled in as a dependent.
-          test "brew", "test", "--verbose", formula_name, env: env
-          test_step = steps.last
-          failed_linkage_or_test_messages << "test failed" if test_step.failed?
+          test "brew", "test", "--verbose", named_args: formula_name, env: env, ignore_failures: ignore_failures
+          failed_linkage_or_test_messages << "test failed" unless steps.last.passed?
         end
 
         # Move bottle and don't test dependents if the formula linkage or test failed.
@@ -391,12 +375,10 @@ module Homebrew
             FileUtils.mv [@bottle_filename, @bottle_json_filename], failed_dir
           end
 
-          if bottled_on_current_version || new_formula
-            failed formula_name, failed_linkage_or_test_messages.join(", ")
-          else
-            linkage_step.ignore if linkage_step.failed?
-            test_step.ignore if test_step&.failed?
+          if ignore_failures
             skipped formula_name, failed_linkage_or_test_messages.join(", ")
+          else
+            failed formula_name, failed_linkage_or_test_messages.join(", ")
           end
         end
       ensure

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -163,8 +163,8 @@ module Homebrew
             d.name == "git" && (!d.test? || d.build?)
           end
           test "brew", "install", *build_args,
-               named_args: dependent.full_name,
-               env: env.merge({ "HOMEBREW_DEVELOPER" => nil }),
+               named_args:      dependent.full_name,
+               env:             env.merge({ "HOMEBREW_DEVELOPER" => nil }),
                ignore_failures: build_from_source && !bottled_on_current_version
 
           return unless steps.last.passed?
@@ -177,7 +177,7 @@ module Homebrew
         end
         test "brew", "install", "--only-dependencies", dependent.full_name
         test "brew", "linkage", "--test",
-             named_args: dependent.full_name,
+             named_args:      dependent.full_name,
              ignore_failures: !bottled_on_current_version
 
         if testable_dependents.include? dependent
@@ -199,8 +199,8 @@ module Homebrew
             d.name == "git" && (!d.build? || d.test?)
           end
           test "brew", "test", "--retry", "--verbose",
-               named_args: dependent.full_name,
-               env: env,
+               named_args:      dependent.full_name,
+               env:             env,
                ignore_failures: !bottled_on_current_version
         end
 

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -162,14 +162,12 @@ module Homebrew
           env["HOMEBREW_GIT_PATH"] = nil if build_from_source && required_dependent_deps.any? do |d|
             d.name == "git" && (!d.test? || d.build?)
           end
-          test "brew", "install", *build_args, dependent.full_name,
-               env: env.merge({ "HOMEBREW_DEVELOPER" => nil })
-          install_step = steps.last
+          test "brew", "install", *build_args,
+               named_args: dependent.full_name,
+               env: env.merge({ "HOMEBREW_DEVELOPER" => nil }),
+               ignore_failures: build_from_source && !bottled_on_current_version
 
-          if install_step.failed?
-            install_step.ignore if build_from_source && !bottled_on_current_version
-            return
-          end
+          return unless steps.last.passed?
         end
         return unless dependent.latest_version_installed?
 
@@ -178,8 +176,9 @@ module Homebrew
           test "brew", "link", dependent.full_name
         end
         test "brew", "install", "--only-dependencies", dependent.full_name
-        test "brew", "linkage", "--test", dependent.full_name
-        steps.last.ignore if steps.last.failed? && !bottled_on_current_version
+        test "brew", "linkage", "--test",
+             named_args: dependent.full_name,
+             ignore_failures: !bottled_on_current_version
 
         if testable_dependents.include? dependent
           test "brew", "install", "--only-dependencies", "--include-test", dependent.full_name
@@ -199,8 +198,10 @@ module Homebrew
           env["HOMEBREW_GIT_PATH"] = nil if required_dependent_deps.any? do |d|
             d.name == "git" && (!d.build? || d.test?)
           end
-          test "brew", "test", "--retry", "--verbose", dependent.full_name, env: env
-          steps.last.ignore if steps.last.failed? && !bottled_on_current_version
+          test "brew", "test", "--retry", "--verbose",
+               named_args: dependent.full_name,
+               env: env,
+               ignore_failures: !bottled_on_current_version
         end
 
         test "brew", "uninstall", "--force", dependent.full_name


### PR DESCRIPTION
This implements a way to produce annotations for all errors in a
`test-bot` run. It requires baking in some assumptions that we are
testing formulae into a `Step`. In exchange, we get annotations on
relevant formula files.

Additionally, a `brew install` or `brew test` failure will place that
annotation on the `install` method or `test` block respectively.

To enable annotations on formula files, we add a `named_args` keyword
argument to the `test` method. Formula names (or `Formula` objects) should be
passed as the value of `named_args` for annotations to be emitted.

I've also moved the `ignore` logic into the `Step` class, so there
should be no need to call `Step#ignore` manually after a `test` if we
wish to ignore errors from that step. Instead, we pass
`ignore_failures: true` to `test`.