### PR TITLE
lib/step: dump the command output instead

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -156,7 +156,7 @@ module Homebrew
 
             annotation_type = failed? ? :error : :warning
             file = path.to_s.delete_prefix("#{@repository}/")
-            emit_annotation("`#{command_short}` failed!", annotation_type, file, line)
+            emit_annotation(@output, annotation_type, file, line)
           end
         end
       end


### PR DESCRIPTION
This might be more useful than the existing generic message. I'm not
sure if we want to keep a `command_short` header for `@output` here, but
let's give this a try and adjust it later on if needed.
