### PR TITLE
formula_dependents: ensure recursive dependencies are linked

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -183,8 +183,8 @@ module Homebrew
         if testable_dependents.include? dependent
           test "brew", "install", "--only-dependencies", "--include-test", dependent.full_name
 
-          dependent.deps.each do |dependency|
-            next if dependency.build?
+          dependent.recursive_dependencies.each do |dependency|
+            next if dependency.build? && !dependency.test?
 
             dependency_f = dependency.to_formula
             next if dependency_f.keg_only?


### PR DESCRIPTION
This might fix the `mathlibtools` error in https://github.com/Homebrew/homebrew-core/pull/89488

```
OSX 'readlink' command does not support option '-f', please install 'greadlink'. If you use 'brew', you can install 'greadlink' using 'brew install coreutils'
```

`mathlibtools` depends on `lean`, which depends on `coreutils`

```rb
Formula["mathlibtools"].deps.map(&:name) # => ["lean", "python@3.10", "six"]
Formula["mathlibtools"].recursive_dependencies.map(&:name) # => ["cmake", "gmp", "coreutils", "jemalloc", "lean", "pkg-config", "gdbm", "mpdecimal", "ca-certificates", "openssl@1.1", "readline", "sqlite", "xz", "python@3.10", "tcl-tk", "python@3.8", "python@3.9", "six"]
```