### PR TITLE
lib/tests/formulae_dependents: link only installed formulae

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -187,6 +187,8 @@ module Homebrew
             next if dependency.build? && !dependency.test?
 
             dependency_f = dependency.to_formula
+            # We don't want to attempt to link runtime deps of build deps.
+            next unless dependency_f.any_version_installed?
             next if dependency_f.keg_only?
             next if dependency_f.linked_keg.exist?
 


### PR DESCRIPTION
We started trying to link recursive dependencies in #711. However, this
causes `test-bot` to attempt to link runtime dependencies of build
dependencies (see reviews at #659). This will error out because those
dependencies will not be installed (cf. Homebrew/homebrew-core#89573).

Let's fix this by only attempting to link recursive dependencies that
are actually installed.
