### PR TITLE
formulae_dependents: display annotations for missing bottles

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -210,6 +210,8 @@ module Homebrew
 
         test "brew", "uninstall", "--force", dependent.full_name
 
+        return if ENV["GITHUB_ACTIONS"].blank?
+
         if build_from_source &&
            !bottled_on_current_version &&
            !dependent_was_previously_installed &&


### PR DESCRIPTION
This change checks for formulae that should be bottled but aren't. When
it finds one, it displays an annotation on the relevant formula.

Closes #678.
