### PR TITLE
formulae_dependents: prune build deps when linking test deps

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -186,14 +186,12 @@ module Homebrew
         if testable_dependents.include? dependent
           test "brew", "install", "--only-dependencies", "--include-test", dependent.full_name
 
-          dependent.recursive_dependencies.each do |dependency|
-            next if dependency.build? && !dependency.test?
+          dependent.recursive_dependencies do |_, dependency|
+            Dependency.prune if dependency.build? && !dependency.test?
 
             dependency_f = dependency.to_formula
-            # We don't want to attempt to link runtime deps of build deps.
-            next unless dependency_f.any_version_installed?
-            next if dependency_f.keg_only?
-            next if dependency_f.linked_keg.exist?
+            Dependency.skip if dependency_f.keg_only?
+            Dependency.skip if dependency_f.linked_keg.exist?
 
             unlink_conflicts dependency_f
             test "brew", "link", dependency_f.full_name


### PR DESCRIPTION
This improves on #711 and #713 by using `Dependency.prune` to skip build dependencies and their recursive dependencies.

Using `Dependency.skip` instead of `next` is technically not needed because the return value of `recursive_dependencies` is not used. However, it makes the intent here clearer: skip the dependency, but continue iterating over its recursive dependencies so they can be linked too.