### PR TITLE
lib/step: skip annotations on Linux (for now)

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -70,6 +70,8 @@ module Homebrew
     end
 
     def emit_annotation(type, message, title, file, line)
+      # https://github.com/Homebrew/homebrew-test-bot/issues/712
+      return if OS.linux?
       return if ENV["GITHUB_ACTIONS"].blank?
 
       annotation = GitHub::Actions::Annotation.new(type, message, title: title, file: file, line: line)


### PR DESCRIPTION
Using `GitHub::Actions::Annotation` causes errors in the Linux
container. See #712.
