### PR TITLE
Display unbottled dependencies when skipping

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -14,6 +14,10 @@ module Homebrew
       protected
 
       def bottled?(formula, no_older_versions: false)
+        # If a formula has an `:all` bottle, then all its dependencies have
+        # to be bottled too for us to use it. We only need to recurse
+        # up the dep tree when we encounter an `:all` bottle because
+        # a formula is not bottled unless its dependencies are.
         if formula.bottle_specification.tag?(Utils::Bottles.tag(:all))
           formula.deps.all? { |dep| bottled?(dep.to_formula, no_older_versions: no_older_versions) }
         else

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -13,8 +13,12 @@ module Homebrew
 
       protected
 
-      def bottled?(formula, tag = nil, no_older_versions: false)
-        formula.bottle_specification.tag?(Utils::Bottles.tag(tag), no_older_versions: no_older_versions)
+      def bottled?(formula, no_older_versions: false)
+        if formula.bottle_specification.tag?(Utils::Bottles.tag(:all))
+          formula.deps.all? { |dep| bottled?(dep.to_formula, no_older_versions: no_older_versions) }
+        else
+          formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: no_older_versions)
+        end
       end
 
       def skipped(formula_name, reason)

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -247,13 +247,17 @@ module Homebrew
           return
         end
 
-        all_deps_have_compatible_bottles = formula.deps.all? do |dep|
-          bottled?(dep.to_formula)
-        end
+        deps_without_compatible_bottles = formula.deps
+                                                 .map(&:to_formula)
+                                                 .reject { |dep| bottled?(dep) }
         bottled_on_current_version = bottled?(formula, no_older_versions: true)
 
-        if !all_deps_have_compatible_bottles && (!bottled_on_current_version || bottled?(formula, :all))
-          skipped formula_name, "#{formula_name} has dependencies without a compatible bottle!"
+        if deps_without_compatible_bottles.present? && !bottled_on_current_version
+          message <<~EOS
+            #{formula_name} has dependencies without compatible bottles:
+              #{deps_without_compatible_bottles * "\n  "}
+          EOS
+          skipped formula_name, message
           return
         end
 


### PR DESCRIPTION
Also, simplify handling of `:all` bottles.

Closes #705.