### PR TITLE
formulae_dependents: build more dependents from source

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -48,8 +48,6 @@ module Homebrew
       def dependents_for_formula(formula, formula_name, args:)
         info_header "Determining dependents..."
 
-        build_dependents_from_source_disabled = OS.linux? && tap.present? && tap.full_name == "Homebrew/homebrew-core"
-
         uses_args = %w[--formula --include-build --include-test]
         uses_args << "--recursive" unless args.skip_recursive_dependents?
         dependents = with_env(HOMEBREW_STDERR: "1") do
@@ -76,15 +74,17 @@ module Homebrew
         end)
 
         # Split into dependents that we could potentially be building from source and those
-        # we should not. The criteria is that it depends on a formula in the allowlist and
-        # that formula has been, or will be, built in this test run.
-        source_dependents, dependents = dependents.partition do |_, deps|
-          deps.any? do |d|
-            full_name = d.to_formula.full_name
+        # we should not. The criteria is that either the `--build-dependents-from-source` flag
+        # was passed or a dependent has no bottle but has useable dependencies.
+        source_dependents, dependents = dependents.partition do |dependent, deps|
+          next false if OS.linux? && dependent.requirements.exclude?(LinuxRequirement.new)
+          next true if args.build_dependents_from_source?
 
-            next false if !args.build_dependents_from_source? || build_dependents_from_source_disabled
+          !bottled?(dependent, no_older_versions: true) && deps.all? do |dep|
+            f = dep.to_formula
+            built_formulae = @testing_formulae - skipped_or_failed_formulae
 
-            @testing_formulae.include?(full_name)
+            bottled?(f) || built_formulae.include?(f.full_name)
           end
         end
 

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -13,6 +13,11 @@ module Homebrew
 
       private
 
+      def bottled_or_built?(formula)
+        built_formulae = @testing_formulae - skipped_or_failed_formulae
+        bottled?(formula) || built_formulae.include?(formula.full_name)
+      end
+
       def dependent_formulae!(formula_name, args:)
         cleanup_during!(args: args)
 
@@ -29,13 +34,6 @@ module Homebrew
           dependents_for_formula(formula, formula_name, args: args)
 
         source_dependents.each do |dependent|
-          next if dependent.deps.any? do |d|
-            f = d.to_formula
-            built_formulae = @testing_formulae - skipped_or_failed_formulae
-
-            !bottled?(f) && built_formulae.exclude?(f.full_name)
-          end
-
           install_dependent(dependent, testable_dependents, build_from_source: true, args: args)
           install_dependent(dependent, testable_dependents, args: args) if bottled?(dependent)
         end
@@ -74,18 +72,16 @@ module Homebrew
         end)
 
         # Split into dependents that we could potentially be building from source and those
-        # we should not. The criteria is that either the `--build-dependents-from-source` flag
-        # was passed or a dependent has no bottle but has useable dependencies.
+        # we should not. The criteria is that a dependent must have bottled dependencies, and
+        # either the `--build-dependents-from-source` flag was passed or a dependent has no
+        # bottle on the current OS.
         source_dependents, dependents = dependents.partition do |dependent, deps|
           next false if OS.linux? && dependent.requirements.exclude?(LinuxRequirement.new)
-          next true if args.build_dependents_from_source?
 
-          !bottled?(dependent, no_older_versions: true) && deps.all? do |dep|
-            f = dep.to_formula
-            built_formulae = @testing_formulae - skipped_or_failed_formulae
+          all_deps_bottled_or_built = deps.all? { |d| bottled_or_built?(d.to_formula) }
+          next all_deps_bottled_or_built if args.build_dependents_from_source?
 
-            bottled?(f) || built_formulae.include?(f.full_name)
-          end
+          all_deps_bottled_or_built && !bottled?(dependent, no_older_versions: true)
         end
 
         # From the non-source list, get rid of any dependents we are only a build dependency to


### PR DESCRIPTION
If the `--build-dependents-from-source` flag is passed, then all
dependents are built from source. This is the current behaviour.

We change behaviour in two ways:
1. Build unbottled dependents from source if all its dependencies are
   either bottled, or were built earlier in the `test-bot` run.
2. Build Linux-only formulae from source too (either with the
   appropriate flag or when the above condition is true) instead of
   always skipping source builds on Linux.

Building unbottled dependents will be useful for detecting dependents
which should be bottled after #714.

This change should also allow us to clean up a bit of code in the
`#dependent_formulae!` method. I've omitted that for now since I have a
pending PR (#717) which introduces conflicting changes.
