### PR TITLE
lib/step: improve GitHub Actions logging and annotations

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -131,9 +131,10 @@ module Homebrew
       [@repository.glob("**/#{name}*").first, nil]
     end
 
-    def truncate_output(output, kb:, lines:)
-      max_length_start = [@output.length - (kb * 1024), 0].max
-      annotation_output = @output[max_length_start..].lines.last(lines).join
+    def truncate_output(output, max_kb:, max_lines:)
+      max_length_start = [output.length - (max_kb * 1024), 0].max
+
+      output[max_length_start..].lines.last(max_lines).join
     end
 
     def run(dry_run: false, fail_fast: false)
@@ -209,7 +210,7 @@ module Homebrew
 
         # GitHub Actions has a 64KB maximum for annotiations. That's a bit
         # too long so instead let's go for a maximum of 24KB or 256 lines.
-        annotation_output = truncate_output(@output, kb: 24, lines: 256)
+        annotation_output = truncate_output(@output, max_kb: 24, max_lines: 256)
 
         annotation_title = "`#{command_trimmed}` failed on #{os_string}!"
         file = path.to_s.delete_prefix("#{@repository}/")


### PR DESCRIPTION
1. Fix output grouping.
2. Don't join with `\n`. `@output.lines` doesn't strip each line, so
   joining with a newline doubles the spacing.

While we're here:
1. Remove `type` from `#puts_github_actions_annotation`, since this
   method can observe the `@status` directly.
2. Remove the redundant `#in_github_actions?` checks in
   `puts_full_output`, since this is already checked for in
   `#puts_in_github_actions_group`.
3. Reduce duplication in `os_string` and avoid hardcoding literals.
