### PR TITLE
Improve whitespace placement

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -168,7 +168,7 @@ module Homebrew
 
       # ActiveSupport can barf on some Unicode so don't use .present?
       if output.empty?
-        puts
+        puts if @verbose
         exit 1 if fail_fast && failed?
         return
       end
@@ -217,7 +217,6 @@ module Homebrew
         end
       end
 
-      puts
       exit 1 if fail_fast && failed?
     end
   end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -14,10 +14,12 @@ module Homebrew
       def run!(args:)
         sorted_formulae.each do |f|
           formula!(f, args: args)
+          puts
         end
 
         @deleted_formulae.each do |f|
           deleted_formula!(f)
+          puts
         end
 
         return unless ENV["GITHUB_ACTIONS"]

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -8,6 +8,7 @@ module Homebrew
       def run!(args:)
         (@testing_formulae - skipped_or_failed_formulae).each do |f|
           dependent_formulae!(f, args: args)
+          puts
         end
       end
 


### PR DESCRIPTION
This should make whitespace placement in the CI log a bit more logical.
