### PR TITLE
formulae: check deps against `testing_formulae` instead

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -233,7 +233,7 @@ module Homebrew
         # but accept an older compatible bottle for test dependencies.
         return false if formula.deps.any? do |dep|
           !bottled?(dep.to_formula, no_older_versions: !dep.test?) &&
-          @added_formulae.exclude?(dep.name)
+          @testing_formulae.exclude?(dep.name)
         end
 
         !formula.bottle_disabled? && !args.build_from_source?


### PR DESCRIPTION
This is a better fix for the issue I tried to fix in #733.

Checking dependents against `@new_formula` allows you to declare a
formula dependency on a new formula added in the same PR. The same thing
is achieved by checking `@testing_formulae` instead, but also accounts
for the case where a PR fixes a previously-unbottled formula `x`, and
also makes `x` a dependency of another formula.
