### PR TITLE
formulae_dependents: build dependents from source only on request

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -80,9 +80,7 @@ module Homebrew
           next false if OS.linux? && dependent.requirements.exclude?(LinuxRequirement.new)
 
           all_deps_bottled_or_built = deps.all? { |d| bottled_or_built?(d.to_formula) }
-          next all_deps_bottled_or_built if args.build_dependents_from_source?
-
-          all_deps_bottled_or_built && !bottled?(dependent, no_older_versions: true)
+          args.build_dependents_from_source? && all_deps_bottled_or_built
         end
 
         # From the non-source list, get rid of any dependents we are only a build dependency to


### PR DESCRIPTION
I trialled this behaviour in Homebrew/homebrew-core#89857, and it adds a
significant amount of time to the CI run. I'm still interested in
automating the detection of formulae that should be bottled, but I think
it requires a more nuanced approach.

In the meantime, let's restore the old behaviour that dependents are
built from source only when requested via a flag.

Closes #731.
