### PR TITLE
formulae: don't skip formulae with a dependent in the same test-bot run

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -25,6 +25,11 @@ module Homebrew
         end
       end
 
+      def bottled_or_built?(formula, no_older_versions: false)
+        built_formulae = @testing_formulae - @skipped_or_failed_formulae
+        bottled?(formula, no_older_versions: no_older_versions) || built_formulae.include?(formula.full_name)
+      end
+
       def skipped(formula_name, reason)
         @skipped_or_failed_formulae << formula_name
 

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -232,8 +232,7 @@ module Homebrew
         # Build and runtime dependencies must be bottled on the current OS,
         # but accept an older compatible bottle for test dependencies.
         return false if formula.deps.any? do |dep|
-          !bottled?(dep.to_formula, no_older_versions: !dep.test?) &&
-          @testing_formulae.exclude?(dep.name)
+          !bottled_or_built?(dep.to_formula, no_older_versions: !dep.test?)
         end
 
         !formula.bottle_disabled? && !args.build_from_source?
@@ -252,7 +251,7 @@ module Homebrew
 
         deps_without_compatible_bottles = formula.deps
                                                  .map(&:to_formula)
-                                                 .reject { |dep| bottled?(dep) }
+                                                 .reject { |dep| bottled_or_built?(dep) }
         bottled_on_current_version = bottled?(formula, no_older_versions: true)
 
         if deps_without_compatible_bottles.present? && !bottled_on_current_version

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -14,11 +14,6 @@ module Homebrew
 
       private
 
-      def bottled_or_built?(formula)
-        built_formulae = @testing_formulae - skipped_or_failed_formulae
-        bottled?(formula) || built_formulae.include?(formula.full_name)
-      end
-
       def dependent_formulae!(formula_name, args:)
         cleanup_during!(args: args)
 


### PR DESCRIPTION
While doing some testing I discovered that adding two new formulae,
where one depends on the other, will cause the dependent to get
skipped.

Let's fix that by also using `#bottled_or_built?` to check dependencies.
