### PR TITLE
formulae_dependents: skip strict linkage check when building from source

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -166,7 +166,7 @@ module Homebrew
              ignore_failures: !bottled_on_current_version
         linkage_step = steps.last
 
-        if linkage_step.passed?
+        if linkage_step.passed? && !build_from_source
           # Check for opportunistic linkage. Ignore failures because
           # they can be unavoidable but we still want to know about them.
           test "brew", "linkage", "--cached", "--test", "--strict",


### PR DESCRIPTION
Building dependents from source is an opportunistic linkage party. We
don't really need to see those warnings.
