### PR TITLE
formulae_dependents: run postinstall before testing dependents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,14 @@ jobs:
       - name: Run Homebrew/homebrew-test-bot RSpec tests
         run: bundle exec rspec
 
-      - name: Build Docker image
+      - name: Build Docker image and start container
         if: matrix.os == 'ubuntu-latest'
-        run: docker build -t brew .
+        run: |
+          docker build -t brew .
+          docker create \
+            -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
+            --name=brewtestbot brew sleep infinity
+          docker start brewtestbot
 
       - run: brew test-bot --only-formulae-detect --test-default-formula
         id: formulae-detect
@@ -59,9 +64,7 @@ jobs:
         id: brew-test-bot-formulae
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            docker run \
-              -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
-              --rm brew \
+            docker exec brewtestbot \
               brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
           else
             brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
@@ -70,12 +73,14 @@ jobs:
       - name: Run brew test-bot --only-formulae-dependents --junit --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            docker run \
-              -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
-              --rm brew \
-              brew test-bot --only-formulae-dependents --junit --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}}
+            docker exec brewtestbot \
+              brew test-bot --only-formulae-dependents --junit \
+                            --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }} \
+                            --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
           else
-            brew test-bot --only-formulae-dependents --junit --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+            brew test-bot --only-formulae-dependents --junit \
+                          --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }} \
+                          --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
           fi
 
       - name: Output brew test-bot failures
@@ -93,9 +98,7 @@ jobs:
       - name: Run brew test-bot --only-cleanup-after
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            docker run \
-              -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
-              --rm brew \
+            docker exec brewtestbot \
               brew test-bot --only-cleanup-after
           else
             brew test-bot --only-cleanup-after
@@ -104,9 +107,7 @@ jobs:
       - name: Run brew test-bot --only-setup --dry-run
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            docker run \
-              -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
-              --rm brew \
+            docker exec brewtestbot \
               brew test-bot --only-setup --dry-run
           else
             brew test-bot --only-setup --dry-run
@@ -115,10 +116,14 @@ jobs:
       - name: Run brew test-bot testbottest --only-formulae --dry-run
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            docker run \
-              -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
-              --rm brew \
+            docker exec brewtestbot \
               brew test-bot testbottest --only-formulae --dry-run
           else
             brew test-bot testbottest --only-formulae --dry-run
           fi
+
+      - name: Cleanup Docker container
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          docker stop brewtestbot
+          docker rm brewtestbot

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -24,6 +24,10 @@ module Homebrew
           return
         end
 
+        # Restore etc/var files that may have been nuked in the build stage.
+        test "brew", "postinstall", formula_name
+        return if steps.last.failed?
+
         formula = Formulary.factory(formula_name)
 
         source_dependents, bottled_dependents, testable_dependents =


### PR DESCRIPTION
This fixes an issue where important etc/var files, which may have been nuked during the build stage, are missing.

Detailed at: https://github.com/Homebrew/homebrew-core/pull/85812#issuecomment-996325061