### PR TITLE
formulae_dependents: install formula dependencies first

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -24,6 +24,11 @@ module Homebrew
           return
         end
 
+        # Install formula dependencies. These will have been uninstalled after building.
+        test "brew", "install", "--only-dependencies", formula_name,
+             env: { "HOMEBREW_DEVELOPER" => nil }
+        return if steps.last.failed?
+
         # Restore etc/var files that may have been nuked in the build stage.
         test "brew", "postinstall", formula_name
         return if steps.last.failed?


### PR DESCRIPTION
The dependencies would have been uninstalled after the build stage to prevent opportunistic linkage, so they'll need to be reinstalled again when testing dependents.

This happened implicitly before, but it now needs to be explicit so that it's done before `postinstall`.