### PR TITLE
test_formulae: fix check for just-built formulae

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -26,7 +26,7 @@ module Homebrew
       end
 
       def bottled_or_built?(formula, no_older_versions: false)
-        built_formulae = @testing_formulae - @skipped_or_failed_formulae
+        built_formulae = testing_formulae - skipped_or_failed_formulae
         bottled?(formula, no_older_versions: no_older_versions) || built_formulae.include?(formula.full_name)
       end
 


### PR DESCRIPTION
The existing check is, unfortunately, still wrong. This is due to a
misunderstanding I had about the scope in which instance variables are
evaluated for derived classes.

This should be better now.

Spotted in Homebrew/homebrew-core#92329.