### PR TITLE
lib/tests/formulae: add `attr_accessor :testing_formulae`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -3,7 +3,8 @@
 module Homebrew
   module Tests
     class Formulae < TestFormulae
-      attr_writer :testing_formulae, :added_formulae, :deleted_formulae
+      attr_accessor :testing_formulae
+      attr_writer :added_formulae, :deleted_formulae
 
       def initialize(tap:, git:, dry_run:, fail_fast:, verbose:, bottle_output_path:)
         super(tap: tap, git: git, dry_run: dry_run, fail_fast: fail_fast, verbose: verbose)


### PR DESCRIPTION
This is needed for #766.

Fixes 
```
Error: undefined local variable or method `testing_formulae' for #<Homebrew::Tests::Formulae:0x00007fc7530ee670>
```
https://github.com/Homebrew/homebrew-core/runs/4791063162?check_suite_focus=true#step:6:21