### PR TITLE
test_formulae: improve `#cleanup_during!`

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -102,8 +102,10 @@ module Homebrew
                        .to_i
         return if free_gb > 10
 
-        installed_formulae = Utils.safe_popen_read("brew", "list", "--formula", "--full-name").strip.split
-        uninstallable_formulae = installed_formulae - built_formulae
+        uninstallable_formulae = if testing_formulae.exclude?("testbottest")
+          installed_formulae = Formula.installed.map(&:full_name)
+          installed_formulae - built_formulae
+        end
 
         if uninstallable_formulae.present?
           test_header(:TestFormulae, method: :cleanup_during!)

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -111,7 +111,8 @@ module Homebrew
         end
 
         return unless HOMEBREW_CACHE.exist?
-        test_header(:TestFormulae, method: :cleanup_during!) unless uninstallable_formulae.present?
+
+        test_header(:TestFormulae, method: :cleanup_during!) if uninstallable_formulae.blank?
 
         FileUtils.chmod_R "u+rw", HOMEBREW_CACHE, force: true
         test "rm", "-rf", HOMEBREW_CACHE.to_s

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -102,7 +102,7 @@ module Homebrew
                        .to_i
         return if free_gb > 10
 
-        installed_formulae = Formula.installed.map(&:full_name)
+        installed_formulae = Utils.safe_popen_read("brew", "list", "--formula", "--full-name").strip.split
         uninstallable_formulae = installed_formulae - built_formulae
 
         if uninstallable_formulae.present?


### PR DESCRIPTION
CI runs that test many dependents often result in deletions of
`HOMEBREW_CACHE` before nearly every tested dependent. See, for example,
the Linux CI run at Homebrew/homebrew-core#92329.

This means that the free space test isn't being met, but deleting
`HOMEBREW_CACHE` is not freeing enough space.

Let's try to free even more space by uninstalling any formulae we can
safely uninstall in addition to deleting `HOMEBREW_CACHE`.
