### PR TITLE
lib/tests/formulae: add a newline in linkage output

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -356,6 +356,7 @@ module Homebrew
 
         test "brew", "linkage", "--cached", formula_name
         @linkage_output_path.write(Formatter.headline(steps.last.command_trimmed, color: :blue), mode: "a")
+        @linkage_output_path.write("\n", mode: "a")
         @linkage_output_path.write(steps.last.output, mode: "a")
 
         test "brew", "install", "--only-dependencies", "--include-test", formula_name


### PR DESCRIPTION
Otherwise the output starts with
```
==> brew linkage --cached midgard2System libraries:
```
https://github.com/Homebrew/homebrew-core/runs/4856865138?check_suite_focus=true#step:10:14
