### PR TITLE
Fix bottling dependents of new formulae

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -25,8 +25,7 @@ module Homebrew
         end
       end
 
-      def bottled_or_built?(formula, no_older_versions: false)
-        built_formulae = testing_formulae - skipped_or_failed_formulae
+      def bottled_or_built?(formula, built_formulae, no_older_versions: false)
         bottled?(formula, no_older_versions: no_older_versions) || built_formulae.include?(formula.full_name)
       end
 

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -3,7 +3,7 @@
 module Homebrew
   module Tests
     class FormulaeDependents < TestFormulae
-      attr_accessor :testing_formulae
+      attr_writer :testing_formulae
 
       def run!(args:)
         (@testing_formulae - skipped_or_failed_formulae).each do |f|
@@ -83,7 +83,9 @@ module Homebrew
         source_dependents, dependents = dependents.partition do |dependent, deps|
           next false if OS.linux? && dependent.requirements.exclude?(LinuxRequirement.new)
 
-          all_deps_bottled_or_built = deps.all? { |d| bottled_or_built?(d.to_formula) }
+          all_deps_bottled_or_built = deps.all? do |d|
+            bottled_or_built?(d.to_formula, @testing_formulae - @skipped_or_failed_formulae)
+          end
           args.build_dependents_from_source? && all_deps_bottled_or_built
         end
 


### PR DESCRIPTION
This is still happening despite my previous attempts to fix it. The
issue is that a formula is removed from the `@testing_formulae` array
once its bottle is successfully built, so I can't check this array to
determine whether a formula was successfully built earlier in the run.

Let's fix that by keeping track of formulae with built bottles
separately.

I tested this a lot more carefully than my previous attempts, so
hopefully this should do it now.

Needed for Homebrew/homebrew-core#92329, Homebrew/homebrew-core#93167,
and Homebrew/homebrew-core#92024.