### PR TITLE
formulae_dependents: determine dependents earlier

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -29,7 +29,7 @@ module Homebrew
         source_dependents, bottled_dependents, testable_dependents =
           dependents_for_formula(formula, formula_name, args: args)
 
-        return if source_dependents.blank? && bottled_dependents.blank? && testable_dependents.blank?
+        return if source_dependents.blank? && bottled_dependents.blank?
 
         # Install formula dependencies. These will have been uninstalled after building.
         test "brew", "install", "--only-dependencies", formula_name,

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -24,6 +24,13 @@ module Homebrew
           return
         end
 
+        formula = Formulary.factory(formula_name)
+
+        source_dependents, bottled_dependents, testable_dependents =
+          dependents_for_formula(formula, formula_name, args: args)
+
+        return if source_dependents.blank? && bottled_dependents.blank? && testable_dependents.blank?
+
         # Install formula dependencies. These will have been uninstalled after building.
         test "brew", "install", "--only-dependencies", formula_name,
              env: { "HOMEBREW_DEVELOPER" => nil }
@@ -32,11 +39,6 @@ module Homebrew
         # Restore etc/var files that may have been nuked in the build stage.
         test "brew", "postinstall", formula_name
         return if steps.last.failed?
-
-        formula = Formulary.factory(formula_name)
-
-        source_dependents, bottled_dependents, testable_dependents =
-          dependents_for_formula(formula, formula_name, args: args)
 
         source_dependents.each do |dependent|
           install_dependent(dependent, testable_dependents, build_from_source: true, args: args)


### PR DESCRIPTION
`brew install --only-dependencies` and `brew postinstall` is a
relatively expensive operation compared to determining dependents. [1]

Let's determine dependents first and return early if a formula has no
dependents to test.

[1] See, for example:
    https://github.com/Homebrew/homebrew-core/runs/5019862178?check_suite_focus=true#step:8:18
