### PR TITLE
formulae_dependents: skip testing dependents of build dependents

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -66,7 +66,8 @@ module Homebrew
           Utils.safe_popen_read("brew", "uses", "--formula", "--include-build", formula_name)
                .split("\n")
         end
-        dependents.uniq!.sort!
+        dependents&.uniq!
+        dependents&.sort!
 
         dependents -= @testing_formulae
         dependents = dependents.map { |d| Formulary.factory(d) }


### PR DESCRIPTION
This is based on the discussion at Homebrew/brew#12455.

My intention is for workflows in Homebrew/core to always pass
`--skip-recursive-build-dependents`, perhaps with a label that causes
the workflow to omit the flag.

I'm tempted to not make this an option at all, but this changes testing
behaviour in external taps too, and I'm a little wary about forcing
those changes when they haven't been asked for.
