### PR TITLE
formulae_dependents: test a dependent only once

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -42,7 +42,7 @@ module Homebrew
           dependents_for_formula(formula, formula_name, args: args)
 
         source_dependents.each do |dependent|
-          next if @source_tested_dependents.include? dependent
+          next if @source_tested_dependents.include?(dependent)
 
           install_dependent(dependent, testable_dependents, build_from_source: true, args: args)
           install_dependent(dependent, testable_dependents, args: args) if bottled?(dependent)
@@ -50,7 +50,8 @@ module Homebrew
         end
 
         bottled_dependents.each do |dependent|
-          next if @bottle_tested_dependents.include? dependent
+          # Testing a dependent from source also tests the bottle (if available).
+          next if @bottle_tested_dependents.include?(dependent) || @source_tested_dependents.include?(dependent)
 
           install_dependent(dependent, testable_dependents, args: args)
           @bottle_tested_dependents << dependent


### PR DESCRIPTION
If a formula depends on two formulae in `@testing_formulae`, then it
gets tested as a dependent twice. [1]

Let's fix that by keeping track of the dependents we've already tested,
and test it only if we haven't tested it previously.

[1] Test this with:

    brew test-bot --dry-run --only-formulae-dependents --testing-formulae=python@3.9,python@3.10
