### PR TITLE
test_bot: allow to override HOMEBREW_CURL_PATH

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -57,7 +57,7 @@ module Homebrew
       ENV["HOMEBREW_NO_EMOJI"] = "1"
       ENV["HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK"] = "1"
       ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
-      ENV["HOMEBREW_CURL_PATH"] = "/usr/bin/curl"
+      ENV["HOMEBREW_CURL_PATH"] = ENV["HOMEBREW_ON_DEBIAN7"].present? ? "/opt/bin/curl" : "/usr/bin/curl"
       ENV["HOMEBREW_GIT_PATH"] = GIT
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV["PATH"]}"


### PR DESCRIPTION
This is necessary for running tests on older Linux systems,
were we provide a newer curl version which is installed in a different path.