### PR TITLE
formulae_dependents: use `--all`.

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -61,7 +61,7 @@ module Homebrew
       def dependents_for_formula(formula, formula_name, args:)
         info_header "Determining dependents..."
 
-        uses_args = %w[--formula --include-test]
+        uses_args = %w[--formula --include-test --all]
         uses_args << "--recursive" unless args.skip_recursive_dependents?
         dependents = with_env(HOMEBREW_STDERR: "1") do
           Utils.safe_popen_read("brew", "uses", *uses_args, formula_name)


### PR DESCRIPTION
Make use of the `brew uses --all` flag added in https://github.com/Homebrew/brew/pull/12935

Blocked on https://github.com/Homebrew/brew/pull/12935