### PR TITLE
add keyword_argument to `FormulaInstaller#new`

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -80,8 +80,7 @@ module Homebrew
 
       def unsatisfied_requirements_messages(formula)
         f = Formulary.factory(formula.full_name)
-        fi = FormulaInstaller.new(f)
-        fi.build_bottle = true
+        fi = FormulaInstaller.new(f, build_bottle: true)
 
         unsatisfied_requirements, = fi.expand_requirements
         return if unsatisfied_requirements.blank?


### PR DESCRIPTION
added keyword argument `build_bottle` to `FormulaInstaller.new` in order to delete `attr_writer` to be deleted which is stated in the comment https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula_installer.rb#L45