### PR TITLE
test_cleanup: don't match --exclude recursively

### DIFF
--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -148,9 +148,9 @@ module Homebrew
 
       clean_args = [
         "-dx",
-        "--exclude=*.bottle*.*",
-        "--exclude=Library/Taps",
-        "--exclude=Library/Homebrew/vendor",
+        "--exclude=/*.bottle*.*",
+        "--exclude=/Library/Taps",
+        "--exclude=/Library/Homebrew/vendor",
       ]
       return if Utils.safe_popen_read(
         git, "-C", repository, "clean", "--dry-run", *clean_args


### PR DESCRIPTION
Fixes a random `*.bottle_manifest.*` lock file deep in the Cellar being matched.

(I should also fix `.bottle` subdirectory dragging in lock files like that - but that's a separate issue.)