### PR TITLE
Fix misnamed variable

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -254,8 +254,8 @@ module Homebrew
 
         return if livecheck_info["version"]["newer_than_upstream"] != true
 
-        current_version = livecheck_json["version"]["current"]
-        latest_version = livecheck_json["version"]["latest"]
+        current_version = livecheck_info["version"]["current"]
+        latest_version = livecheck_info["version"]["latest"]
 
         newer_than_upstream_msg = if current_version.present? && latest_version.present?
           "The formula version (#{current_version}) is newer than the " \


### PR DESCRIPTION
This is a follow-up to #802, where I reworked some of the livecheck tests. It was [brought to my attention](https://github.com/Homebrew/homebrew-test-bot/commit/6e5b9dbd11338e55995293df9852ece37123af3d#r73450218) that I accidentally referred to the `livecheck_info` variable as `livecheck_json` in a couple places and this is predictably causing issues. This PR resolves the issue by renaming the misnamed variables.