### PR TITLE
Set `HOMEBREW_DISALLOW_LIBCRYPT1`

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -59,6 +59,7 @@ module Homebrew
       ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
       ENV["HOMEBREW_CURL_PATH"] = "/usr/bin/curl"
       ENV["HOMEBREW_GIT_PATH"] = GIT
+      ENV["HOMEBREW_DISALLOW_LIBCRYPT1"] = "1"
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
 


### PR DESCRIPTION
This will help stop taps that make use of `test-bot` from producing
bottles with linkage to `libcrypt.so.1`. Linking with `libcrypt1.so.1`
is deprecated and will be broken when we ship a new `glibc` that does
not include `libcrypt.so.1`.
