### PR TITLE
formulae: unlink `boost` when building `mysql`, etc.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -70,6 +70,21 @@ module Homebrew
         formula.recursive_dependencies.each do |dependency|
           conflicts += dependency.to_formula.conflicts
         end
+
+        build_fails_with_boost_installed = %w[mysql percona-server percona-xtrabackup]
+        if build_fails_with_boost_installed.include?(formula_name)
+          boost = begin
+            Formula["boost"]
+          rescue FormulaUnavailableError
+            nil
+          end
+
+          if boost.present?
+            conflicts << boost
+            conflicts += boost.versioned_formulae
+          end
+        end
+
         unlink_formulae = conflicts.map(&:name)
         unlink_formulae.uniq.each do |name|
           unlink_formula = Formulary.factory(name)


### PR DESCRIPTION
When building `mysql`, `percona-server`, and `percona-xtrabackup` and
`boost` is installed, CMake fails with an error like

    CMake Error at CMakeLists.txt:1935 (MESSAGE):
      WITH_ICU=system is not compatible with Homebrew boost

      MySQL depends on boost_1_77_0 with a set of patches.

      Including headers from /opt/homebrew/include will break the build.

      Please use WITH_ICU=bundled

      or do 'brew uninstall boost' or 'brew unlink boost'

We don't have a mechanism to declare build-time-only conflicts, and I'm
not sure this is enough to justify one. Let's just let `test-bot` handle
the `brew unlink boost` step when necessary.

Needed for Homebrew/homebrew-core#98809.
