### PR TITLE
tap_syntax: exclude GCC dependency audit.

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -12,7 +12,7 @@ module Homebrew
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
         test "brew", "style", tap.name unless broken_xcode_rubygems
 
-        test "brew", "audit", "--tap=#{tap.name}", "--except=version"
+        test "brew", "audit", "--tap=#{tap.name}", "--except=version,gcc_dependency"
       end
     end
   end


### PR DESCRIPTION
This slows down the tap syntax job significantly.

See Homebrew/brew#13750.
