### PR TITLE
Revert "tap_syntax: exclude GCC dependency audit."

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -12,7 +12,7 @@ module Homebrew
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
         test "brew", "style", tap.name unless broken_xcode_rubygems
 
-        test "brew", "audit", "--tap=#{tap.name}", "--except=version,gcc_dependency"
+        test "brew", "audit", "--tap=#{tap.name}", "--except=version"
       end
     end
   end


### PR DESCRIPTION
This is no longer needed. See Homebrew/brew#13750.

This reverts commit 82ce00faf85401a8b9067543f96d1d15dbe01952.
