### PR TITLE
tap_syntax: remove `--except=version`.

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -12,7 +12,7 @@ module Homebrew
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
         test "brew", "style", tap.name unless broken_xcode_rubygems
 
-        test "brew", "audit", "--tap=#{tap.name}", "--except=version"
+        test "brew", "audit", "--tap=#{tap.name}"
       end
     end
   end


### PR DESCRIPTION
This doesn't slow the tap syntax job down by much:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `brew audit --tap=homebrew/core --except=version` | 143.878 ± 2.262 | 140.325 | 146.362 | 1.00 |
| `brew audit --tap=homebrew/core ` | 145.160 ± 2.476 | 141.643 | 148.119 | 1.01 ± 0.02 |

Benchmark conducted on Ubuntu 20.04 with `HOMEBREW_SIMULATE_MACOS_ON_LINUX` set, against

```
Homebrew 3.5.10-49-gb2ddb34
Homebrew/homebrew-core (git revision c78aa5d8dd8; last commit 2022-08-25)
```

More details available [here](https://github.com/carlocab/workflow-test/actions/runs/2928925233/attempts/1#summary-8023071550).
