### PR TITLE
formulae: run `brew deps --tree`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -287,6 +287,8 @@ module Homebrew
           return
         end
 
+        test "brew", "deps", "--tree", "--annotate", "--include-build", "--include-test", formula_name
+
         deps_without_compatible_bottles = formula.deps.map(&:to_formula)
         deps_without_compatible_bottles.reject! do |dep|
           bottled_or_built?(dep, @built_formulae - @skipped_or_failed_formulae)


### PR DESCRIPTION
This is useful for debugging and will detect circular dependencies.

Fixes https://github.com/Homebrew/brew/issues/13774