### PR TITLE
formulae_dependents: prune more recursive dependencies

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -82,7 +82,9 @@ module Homebrew
             f.deps
           else
             begin
-              f.recursive_dependencies
+              Dependency.expand(f, cache_key: "test-bot-dependents") do |_, dependency|
+                Dependency.keep_but_prune_recursive_deps if dependency.build? && !dependency.test?
+              end
             rescue TapFormulaUnavailableError => e
               raise if e.tap.installed?
 


### PR DESCRIPTION
The dependencies of build dependencies do not inherit the `:build` tag
when expanding via `#recursive_dependencies`. This results in `test-bot`
testing build-only dependents when it doesn't need to. See
Homebrew/homebrew-core#109250.

Let's fix that by pruning the dep tree whenever we encounter a build
dependency while expanding a dependent's dep tree. In the case of
`ninja`, this will result in `test-bot` correctly identifying that it
only needs to test formulae with a runtime dependency on `ninja`.
