### PR TITLE
lib/test_bot: disallow `libnsl.so.1`.

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -59,7 +59,7 @@ module Homebrew
       ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
       ENV["HOMEBREW_CURL_PATH"] = "/usr/bin/curl"
       ENV["HOMEBREW_GIT_PATH"] = GIT
-      ENV["HOMEBREW_DISALLOW_LIBCRYPT1"] = "1"
+      ENV["HOMEBREW_DISALLOW_LIBNSL1"] = "1"
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
 


### PR DESCRIPTION
The bottles that we ship that link to the old `libnsl` will break on
systems with newer Glibc. Any existing bottles that have this linkage
have likely already been broken by upgrading `glibc` to 2.35.

Also, `HOMEBREW_DISALLOW_LIBCRYPT1` is now a no-op, so we can get rid of
it.
