### PR TITLE
test_bot: set `HOMEBREW_EVAL_ALL`.

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -60,6 +60,7 @@ module Homebrew
       ENV["HOMEBREW_CURL_PATH"] = "/usr/bin/curl"
       ENV["HOMEBREW_GIT_PATH"] = GIT
       ENV["HOMEBREW_DISALLOW_LIBNSL1"] = "1"
+      ENV["HOMEBREW_EVAL_ALL"] = "1"
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
 

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -56,7 +56,7 @@ module Homebrew
       def dependents_for_formula(formula, formula_name, args:)
         info_header "Determining dependents..."
 
-        uses_args = %w[--formula --include-test --all]
+        uses_args = %w[--formula --include-test --eval-all]
         uses_args << "--recursive" unless args.skip_recursive_dependents?
         dependents = with_env(HOMEBREW_STDERR: "1") do
           Utils.safe_popen_read("brew", "uses", *uses_args, formula_name)


### PR DESCRIPTION
`test-bot` needs to be able to evaluate all formulae to:
1. run `tap-syntax`
2. determine dependents

There may be other places it needs this, but those are just the ones off
the top of my head.

To do this, we need to set `HOMEBREW_EVAL_ALL` after #13790.

Fixes:

    Error: Calling brew uses --all is deprecated! Use brew uses --eval-all or HOMEBREW_EVAL_ALL instead.

See https://github.com/Homebrew/homebrew-core/runs/8190122846?check_suite_focus=true#step:10:22.
