### PR TITLE
Dockerfile: update image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM homebrew/ubuntu16.04:master
+FROM homebrew/ubuntu22.04:master
 
 COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-test-bot


### PR DESCRIPTION
We should use `ubuntu22.04` as in everywhere else.
