### PR TITLE
tests/formulae: audit Linux-only GCC dependency earlier.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -290,6 +290,9 @@ module Homebrew
           return
         end
 
+        test "brew", "audit", "--strict", "--only=gcc_dependency", formula_name
+        return unless steps.last.passed?
+
         test "brew", "deps", "--tree", "--annotate", "--include-build", "--include-test", formula_name
 
         deps_without_compatible_bottles = formula.deps.map(&:to_formula)
@@ -396,7 +399,6 @@ module Homebrew
         livecheck(formula) unless skip_online_checks
 
         test "brew", "audit", *audit_args unless formula.deprecated?
-        test "brew", "audit", "--strict", "--only=gcc_dependency", formula_name
         unless install_step.passed?
           if ignore_failures
             skipped formula_name, "install failed"


### PR DESCRIPTION
Let's fail more quickly if a formula has a Linux-only GCC dependency to
avoid wasting CI time on a build that we don't intend to use.
