### PR TITLE
Add `--skip-livecheck` option

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -55,6 +55,8 @@ module Homebrew
              description: "Don't pass `--online` to `brew audit` and skip `brew livecheck`."
       switch "--skip-dependents",
              description: "Don't test any dependents."
+      switch "--skip-livecheck",
+             description: "Don't test livecheck."
       switch "--skip-recursive-dependents",
              description: "Only test the direct dependents."
       switch "--only-cleanup-before",

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -399,7 +399,7 @@ module Homebrew
              ignore_failures: ignore_failures
         install_step = steps.last
 
-        livecheck(formula) unless skip_online_checks
+        livecheck(formula) if !args.skip_livecheck? && !skip_online_checks
 
         test "brew", "audit", *audit_args unless formula.deprecated?
         unless install_step.passed?


### PR DESCRIPTION
Sometimes livecheck will work for a formula locally but fail on CI (intermittently or consistently) and this can force us to merge a PR with failing CI when there isn't an obvious solution. Ideally, we should identify the underlying source of the failure and resolve it but a `--skip-livecheck` option may be useful when that's not immediately possible or the failure point is out of our control (e.g., an upstream server issue).

For example, the `livecheck` blocks for the `aqbanking` and `gwenhywfar` formulae work fine locally but have consistently timed out on macOS CI since around January 2022 and PRs have simply been merged despite the CI failure. This is currently the case in Homebrew/homebrew-core#110571, so I thought we may want to consider making it possible to optionally skip livecheck on CI to allow the PR to pass (i.e., I don't have any idea what the issue is with respect to the CI environment and I'm not sure how we would debug it on CI).

If we move forward with this option, I will add a `CI-skip-livecheck` label in homebrew/core and open a related PR to modify the `tests.yml` workflow to set the `--skip-livecheck` option when the label is present (as we do with other options/labels). [I already have this work done, so I can create the homebrew/core PR if/when appropriate.]