### PR TITLE
tap_syntax: only readall/audit if formula/cask files exist.

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -6,12 +6,13 @@ module Homebrew
       def run!(args:)
         test_header(:TapSyntax)
 
-        test "brew", "readall", "--aliases", tap.name
-
         broken_xcode_rubygems = MacOS.version == :mojave &&
                                 MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
         test "brew", "style", tap.name unless broken_xcode_rubygems
 
+        return if tap.formula_files.blank? && tap.cask_files.blank?
+
+        test "brew", "readall", "--aliases", tap.name
         test "brew", "audit", "--tap=#{tap.name}"
       end
     end


### PR DESCRIPTION
An audit of no files now throws an error.

Needed for e.g. https://github.com/Homebrew/homebrew-formula-analytics