### PR TITLE
test-bot: replace set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,12 @@ jobs:
         run: |
           docker build -t brew .
           docker create \
-            -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
+            -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_OUTPUT -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
+            -v "$GITHUB_OUTPUT:$GITHUB_OUTPUT" \
             --name=brewtestbot brew sleep infinity
           docker start brewtestbot
+          docker exec brewtestbot \
+            sudo setfacl -Rm "d:u:linuxbrew:rwX,u:linuxbrew:rwX" "$RUNNER_TEMP"
 
       - run: brew test-bot --only-formulae-detect --test-default-formula
         id: formulae-detect

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -29,7 +29,9 @@ module Homebrew
 
         return unless ENV["GITHUB_ACTIONS"]
 
-        puts "::set-output name=skipped_or_failed_formulae::#{@skipped_or_failed_formulae.join(",")}"
+        File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
+          f.puts "skipped_or_failed_formulae=#{@skipped_or_failed_formulae.join(",")}"
+        end
       end
 
       private

--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -18,9 +18,11 @@ module Homebrew
 
         return unless ENV["GITHUB_ACTIONS"]
 
-        puts "::set-output name=testing_formulae::#{@testing_formulae.join(",")}"
-        puts "::set-output name=added_formulae::#{@added_formulae.join(",")}"
-        puts "::set-output name=deleted_formulae::#{@deleted_formulae.join(",")}"
+        File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
+          f.puts "testing_formulae=#{@testing_formulae.join(",")}"
+          f.puts "added_formulae=#{@added_formulae.join(",")}"
+          f.puts "deleted_formulae=#{@deleted_formulae.join(",")}"
+        end
       end
 
       private


### PR DESCRIPTION
This PR replaces the `set-output` commands with the `GITHUB_OUTPUT` environment file to set the outputs in GitHub Actions.
Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/