### PR TITLE
tests/formulae: make dependency tree failures an annotation

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -296,7 +296,7 @@ module Homebrew
           return
         end
 
-        test "brew", "deps", "--tree", "--annotate", "--include-build", "--include-test", formula_name
+        test "brew", "deps", "--tree", "--annotate", "--include-build", "--include-test", named_args: formula_name
 
         deps_without_compatible_bottles = formula.deps.map(&:to_formula)
         deps_without_compatible_bottles.reject! do |dep|


### PR DESCRIPTION
Not tested, but this should hopefully prevent reoccurrences of https://github.com/Homebrew/homebrew-core/pull/115951.