### PR TITLE
lib/test_bot: don't install from API (yet, at least).

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -64,6 +64,7 @@ module Homebrew
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
       # https://github.com/Homebrew/brew/issues/14274
       ENV["PYTHONDONTWRITEBYTECODE"] = "1"
+      ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
 
       if args.local?
         home = "#{Dir.pwd}/home"


### PR DESCRIPTION
This is causing mass `brew audit` failures currently.