### PR TITLE
Fix errors when Homebrew/core is untapped

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -64,7 +64,6 @@ module Homebrew
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
       # https://github.com/Homebrew/brew/issues/14274
       ENV["PYTHONDONTWRITEBYTECODE"] = "1"
-      ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
 
       if args.local?
         home = "#{Dir.pwd}/home"
@@ -76,6 +75,9 @@ module Homebrew
       end
 
       tap = resolve_test_tap(args.tap)
+
+      ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1" if tap.to_s == CoreTap.instance.name
+
       # Tap repository if required, this is done before everything else
       # because Formula parsing and/or git commit hash lookup depends on it.
       # At the same time, make sure Tap is not a shallow clone.
@@ -108,7 +110,7 @@ module Homebrew
       ).strip
       puts Formatter.headline("Using Homebrew/brew #{brew_version} (#{brew_commit_subject})", color: :cyan)
 
-      if tap.to_s != CoreTap.instance.name
+      if tap.to_s != CoreTap.instance.name && CoreTap.instance.installed?
         core_revision = Utils.safe_popen_read(
           GIT, "-C", CoreTap.instance.path.to_s,
           "log", "-1", "--format=%h (%s)"

--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -7,12 +7,12 @@ module Homebrew
   class TestCleanup < Test
     protected
 
-    REQUIRED_TAPS = %W[
-      #{CoreTap.instance.name}
+    REQUIRED_TAPS = %w[
       homebrew/test-bot
     ].freeze
 
-    ALLOWED_TAPS = (REQUIRED_TAPS + %w[
+    ALLOWED_TAPS = (REQUIRED_TAPS + %W[
+      #{CoreTap.instance.name}
       homebrew/bundle
       homebrew/cask
       homebrew/cask-versions

--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -6,15 +6,8 @@ module Homebrew
       def run!(args:)
         test_header(:CleanupBefore)
 
-        if tap.to_s != CoreTap.instance.name
-          core_path = CoreTap.instance.path
-          if core_path.exist?
-            reset_if_needed(core_path.to_s)
-          else
-            test git, "clone",
-                 CoreTap.instance.default_remote,
-                 core_path.to_s
-          end
+        if tap.to_s != CoreTap.instance.name && CoreTap.instance.installed?
+          reset_if_needed(CoreTap.instance.path.to_s)
         end
 
         Pathname.glob("*.bottle*.*").each(&:unlink)


### PR DESCRIPTION
Needed for Homebrew/actions#332.

Allowing at least the bare minimum of this to work without Homebrew/core tapped seems sensible.

This fix is for non-core CI primarily as we should be tapped still for core CI.