### PR TITLE
formulae_detect: fix classification of formulae

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -127,7 +127,7 @@ module Homebrew
         end
 
         # If a formula is both added and deleted: it's actually modified.
-        added_and_deleted_formulae = @added_formulae | @deleted_formulae
+        added_and_deleted_formulae = @added_formulae & @deleted_formulae
         @added_formulae -= added_and_deleted_formulae
         @deleted_formulae -= added_and_deleted_formulae
         modified_formulae += added_and_deleted_formulae


### PR DESCRIPTION
Noticed this in https://github.com/Homebrew/homebrew-core/pull/124234 and https://github.com/Homebrew/homebrew-core/pull/124427. They should have failed the notability audit, but since @BrewTestBot did not classify them as added, no `brew audit --new` was done.

This should also explain why CI failed in https://github.com/Homebrew/homebrew-core/pull/124431 where the formula is removed.

This logic was added in https://github.com/Homebrew/homebrew-test-bot/pull/876.
