### PR TITLE
lib/tests/formulae: pass `--formula` to `brew livecheck`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -225,7 +225,7 @@ module Homebrew
         return unless formula.livecheckable?
         return if formula.livecheck.skip?
 
-        livecheck_step = test "brew", "livecheck", "--json", "--full-name", formula.full_name
+        livecheck_step = test "brew", "livecheck", "--formula", "--json", "--full-name", formula.full_name
 
         return if livecheck_step.failed?
         return unless livecheck_step.output?


### PR DESCRIPTION
This is to avoid the failure seen in https://github.com/Homebrew/homebrew-core/pull/124651. We should explicitly pass `--formula` so that the `JSON.parse` doesn't error out when there's a cask of the same name:
```
Error: unexpected token at 'Warning: Treating puzzles as a formula. For the cask, use homebrew/cask/puzzles
[
  {
    "formula": "puzzles",
    "version": {
      "current": "20230302",
      "latest": "20230302",
      "outdated": false,
      "newer_than_upstream": false
    }
  }
]
'
```