### PR TITLE
Remove use of `pluralize`

### DIFF
--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -73,12 +73,12 @@ module Homebrew
         output_lines = []
 
         if ignored_steps.present?
-          output_lines += ["Warning: #{ignored_steps.count} failed #{"step".pluralize(ignored_steps.count)} ignored!"]
+          output_lines += ["Warning: #{ignored_steps.count} failed step#{"s" if ignored_steps.count > 1} ignored!"]
           output_lines += ignored_steps.map(&:command_trimmed)
         end
 
         if failed_steps.present?
-          output_lines += ["Error: #{failed_steps.count} failed #{"step".pluralize(failed_steps.count)}!"]
+          output_lines += ["Error: #{failed_steps.count} failed step#{"s" if failed_steps.count > 1}!"]
           output_lines += failed_steps.map(&:command_trimmed)
         end
 


### PR DESCRIPTION
This was replaced by a method in `Utils`, but we don't really need that
here either.

See Homebrew/brew#14778.
