### PR TITLE
Fix passing of `skipped_or_failed_formulae` to `test_deps`

### DIFF
--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -31,14 +31,18 @@ module Homebrew
 
       bottle_output_path = Pathname("bottle_output.txt")
       linkage_output_path = Pathname("linkage_output.txt")
+      @skipped_or_failed_formulae_output_path = Pathname("skipped_or_failed_formulae-#{Utils::Bottles.tag}.txt")
+
       if no_only_args?(args) || args.only_formulae?
         ensure_blank_file_exists!(bottle_output_path)
         ensure_blank_file_exists!(linkage_output_path)
+        ensure_blank_file_exists!(@skipped_or_failed_formulae_output_path)
       end
 
       output_paths = {
-        bottle:  bottle_output_path,
-        linkage: linkage_output_path,
+        bottle:                     bottle_output_path,
+        linkage:                    linkage_output_path,
+        skipped_or_failed_formulae: @skipped_or_failed_formulae_output_path,
       }
 
       test_bot_args = args.named.dup
@@ -209,8 +213,10 @@ module Homebrew
           formulae_test.run!(args: args)
 
           formulae_test.skipped_or_failed_formulae
-        else
+        elsif args.skipped_or_failed_formulae.present?
           Array(args.skipped_or_failed_formulae)
+        elsif @skipped_or_failed_formulae_output_path.exist?
+          @skipped_or_failed_formulae_output_path.read.chomp.split(",")
         end
 
         if (dependents_test = tests[:formulae_dependents])

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -11,6 +11,7 @@ module Homebrew
         @built_formulae = []
         @bottle_output_path = output_paths[:bottle]
         @linkage_output_path = output_paths[:linkage]
+        @skipped_or_failed_formulae_output_path = output_paths[:skipped_or_failed_formulae]
       end
 
       def run!(args:)
@@ -32,6 +33,8 @@ module Homebrew
         File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
           f.puts "skipped_or_failed_formulae=#{@skipped_or_failed_formulae.join(",")}"
         end
+
+        @skipped_or_failed_formulae_output_path.write(@skipped_or_failed_formulae.join(","))
       end
 
       private


### PR DESCRIPTION
The list of skipped or failed formulae is currently not being passed
correctly to the separate `test_deps` job after this was split in
Homebrew/homebrew-core#125595.

The current way of passing this list through step outputs is tricky to
get right with matrix jobs. However, we already pass a `bottles`
artifact between these jobs, so we can use that to record the
information that we need to pass on to the `test_deps` job.

When this is merged, we only need to remove the
`--skipped-or-failed-formulae` argument in the `brew test-bot`
invocation in the `test_deps` job.
