### PR TITLE
formulae_dependents: dump list of skipped formulae

### DIFF
--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -217,6 +217,8 @@ module Homebrew
           Array(args.skipped_or_failed_formulae)
         elsif @skipped_or_failed_formulae_output_path.exist?
           @skipped_or_failed_formulae_output_path.read.chomp.split(",")
+        else
+          []
         end
 
         if (dependents_test = tests[:formulae_dependents])

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -6,6 +6,9 @@ module Homebrew
       attr_writer :testing_formulae
 
       def run!(args:)
+        info_header "Skipped or failed formulae:"
+        puts skipped_or_failed_formulae
+
         @source_tested_dependents = []
         @bottle_tested_dependents = []
 


### PR DESCRIPTION
This will be useful for debugging purposes, in the same way that we dump
the list of dependents for each testing formula.

Also, fall through to an empty array if we can't determine the skipped
or failed formulae through normal means. This allows dependent testing
to continue assuming that none of the testing formulae failed.
