### PR TITLE
formulae_dependents: unlink formula after bottle install

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -34,6 +34,7 @@ module Homebrew
           end
 
           test "brew", "install", "--ignore-dependencies", "--skip-post-install", bottle_filename
+          test "brew", "unlink", formula_name
           puts
         end
       end


### PR DESCRIPTION
Sometimes, we might install multiple bottles that conflict with each
other. This results in an error when we install the second conflicting
bottle.

See https://github.com/Homebrew/homebrew-core/actions/runs/4572386951/jobs/8072393102?pr=127134#step:7:30
