### PR TITLE
formulae_dependents: add debug output

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -52,6 +52,12 @@ module Homebrew
              env: { "HOMEBREW_DEVELOPER" => nil }
         return if steps.last.failed?
 
+        # Do `brew list` to help debug Homebrew/homebrew-core#127133.
+        test "brew", "list", "--formulae"
+        steps.last.puts_full_output
+        test "brew", "list", "--formula", "shared-mime-info", ignore_failures: true
+        steps.last.puts_full_output
+
         # Restore etc/var files that may have been nuked in the build stage.
         test "brew", "postinstall", formula_name
         return if steps.last.failed?


### PR DESCRIPTION
`brew postinstall` keeps failing in Homebrew/homebrew-core#127133. Let's
add some output to try to debug this.
