### PR TITLE
formulae_dependents: add more debug output

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -50,6 +50,8 @@ module Homebrew
         # Install formula dependencies. These may not be installed.
         test "brew", "install", "--only-dependencies", formula_name,
              env: { "HOMEBREW_DEVELOPER" => nil }
+        # Dump the full output here to help debug Homebrew/homebrew-core#127133.
+        steps.last.puts_full_output
         return if steps.last.failed?
 
         # Do `brew list` to help debug Homebrew/homebrew-core#127133.


### PR DESCRIPTION
This is also for Homebrew/homebrew-core#127133.
