### PR TITLE
formulae_detect: reject casks.

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -191,6 +191,7 @@ module Homebrew
           start_revision, end_revision, "--", path
         ).lines.map do |line|
           file = Pathname.new line.chomp
+          next if tap.cask_file?(file)
           next unless tap.formula_file?(file)
 
           tap.formula_file_to_name(file)


### PR DESCRIPTION
Casks are only ever under `Casks` but formulae can be in many places (including the repository root).

Fixes #897