### PR TITLE
Revert "Merge pull request #899 from Homebrew/formula_detect_cask"

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -191,7 +191,6 @@ module Homebrew
           start_revision, end_revision, "--", path
         ).lines.map do |line|
           file = Pathname.new line.chomp
-          next if tap.cask_file?(file)
           next unless tap.formula_file?(file)
 
           tap.formula_file_to_name(file)


### PR DESCRIPTION
This PR reverts PR #899 which fixed issue #897.

The cause of #897 was later identified as coming from `Homebrew/brew` itself, and has been fixed in
- https://github.com/Homebrew/brew/pull/15150

Thus in `homebrew-test-bot` here #899 can be safely reverted.