### PR TITLE
Add `--only-bottles-fetch` flag

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -71,8 +71,8 @@ module Homebrew
              description: "Only run the formulae detection steps."
       switch "--only-formulae-dependents",
              description: "Only run the formulae dependents steps."
-      switch "--only-formulae-fetch",
-             description: "Only run the formulae fetch steps. This optional post-upload test checks that all " \
+      switch "--only-bottles-fetch",
+             description: "Only run the bottles fetch steps. This optional post-upload test checks that all " \
                           "the bottles were uploaded correctly. It is not run unless requested and only needs " \
                           "to be run on a single machine. The bottle commit to be tested must be on the tested " \
                           "branch."

--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -72,7 +72,10 @@ module Homebrew
       switch "--only-formulae-dependents",
              description: "Only run the formulae dependents steps."
       switch "--only-formulae-fetch",
-             description: "Only run the formulae fetch steps."
+             description: "Only run the formulae fetch steps. This optional post-upload test checks that all " \
+                          "the bottles were uploaded correctly. It is not run unless requested and only needs " \
+                          "to be run on a single machine. The bottle commit to be tested must be on the tested " \
+                          "branch."
       switch "--only-cleanup-after",
              description: "Only run the post-cleanup step. Needs `--cleanup`."
       comma_array "--testing-formulae=",

--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -71,6 +71,8 @@ module Homebrew
              description: "Only run the formulae detection steps."
       switch "--only-formulae-dependents",
              description: "Only run the formulae dependents steps."
+      switch "--only-formulae-fetch",
+             description: "Only run the formulae fetch steps."
       switch "--only-cleanup-after",
              description: "Only run the post-cleanup step. Needs `--cleanup`."
       comma_array "--testing-formulae=",

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -8,6 +8,7 @@ require_relative "tests/cleanup_after"
 require_relative "tests/cleanup_before"
 require_relative "tests/formulae_detect"
 require_relative "tests/formulae_dependents"
+require_relative "tests/formulae_fetch"
 require_relative "tests/formulae"
 require_relative "tests/setup"
 require_relative "tests/tap_syntax"
@@ -111,6 +112,7 @@ module Homebrew
                  args.only_formulae? ||
                  args.only_formulae_detect? ||
                  args.only_formulae_dependents? ||
+                 args.only_formulae_fetch? ||
                  args.only_cleanup_after?
       !any_only
     end
@@ -180,6 +182,14 @@ module Homebrew
         end
       end
 
+      if args.only_formulae_fetch?
+        tests[:formulae_fetch] = Tests::FormulaeFetch.new(tap:       tap,
+                                                          git:       git,
+                                                          dry_run:   args.dry_run?,
+                                                          fail_fast: args.fail_fast?,
+                                                          verbose:   args.verbose?)
+      end
+
       tests
     end
 
@@ -226,6 +236,12 @@ module Homebrew
           dependents_test.skipped_or_failed_formulae = skipped_or_failed_formulae
 
           dependents_test.run!(args: args)
+        end
+
+        if (fetch_test = tests[:formulae_fetch])
+          fetch_test.testing_formulae = testing_formulae
+
+          fetch_test.run!(args: args)
         end
       ensure
         tests[:cleanup_after]&.run!(args: args)

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -8,7 +8,7 @@ require_relative "tests/cleanup_after"
 require_relative "tests/cleanup_before"
 require_relative "tests/formulae_detect"
 require_relative "tests/formulae_dependents"
-require_relative "tests/formulae_fetch"
+require_relative "tests/bottles_fetch"
 require_relative "tests/formulae"
 require_relative "tests/setup"
 require_relative "tests/tap_syntax"
@@ -112,7 +112,7 @@ module Homebrew
                  args.only_formulae? ||
                  args.only_formulae_detect? ||
                  args.only_formulae_dependents? ||
-                 args.only_formulae_fetch? ||
+                 args.only_bottles_fetch? ||
                  args.only_cleanup_after?
       !any_only
     end
@@ -182,12 +182,12 @@ module Homebrew
         end
       end
 
-      if args.only_formulae_fetch?
-        tests[:formulae_fetch] = Tests::FormulaeFetch.new(tap:       tap,
-                                                          git:       git,
-                                                          dry_run:   args.dry_run?,
-                                                          fail_fast: args.fail_fast?,
-                                                          verbose:   args.verbose?)
+      if args.only_bottles_fetch?
+        tests[:bottles_fetch] = Tests::BottlesFetch.new(tap:       tap,
+                                                        git:       git,
+                                                        dry_run:   args.dry_run?,
+                                                        fail_fast: args.fail_fast?,
+                                                        verbose:   args.verbose?)
       end
 
       tests
@@ -238,7 +238,7 @@ module Homebrew
           dependents_test.run!(args: args)
         end
 
-        if (fetch_test = tests[:formulae_fetch])
+        if (fetch_test = tests[:bottles_fetch])
           fetch_test.testing_formulae = testing_formulae
 
           fetch_test.run!(args: args)

--- a/lib/tests/bottles_fetch.rb
+++ b/lib/tests/bottles_fetch.rb
@@ -2,7 +2,7 @@
 
 module Homebrew
   module Tests
-    class FormulaeFetch < TestFormulae
+    class BottlesFetch < TestFormulae
       attr_accessor :testing_formulae
 
       def run!(args:)
@@ -11,14 +11,14 @@ module Homebrew
         puts
 
         testing_formulae.each do |formula_name|
-          fetch_formula!(formula_name, args: args)
+          fetch_bottles!(formula_name, args: args)
           puts
         end
       end
 
       private
 
-      def fetch_formula!(formula_name, args:)
+      def fetch_bottles!(formula_name, args:)
         formula = Formula[formula_name]
         tags = formula.bottle_specification.collector.tags
 

--- a/lib/tests/formulae_fetch.rb
+++ b/lib/tests/formulae_fetch.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Homebrew
+  module Tests
+    class FormulaeFetch < TestFormulae
+      attr_accessor :testing_formulae
+
+      def run!(args:)
+        info_header "Testing formulae:"
+        puts testing_formulae
+        puts
+
+        testing_formulae.each do |formula_name|
+          fetch_formula!(formula_name, args: args)
+          puts
+        end
+      end
+
+      private
+
+      def fetch_formula!(formula_name, args:)
+        formula = Formula[formula_name]
+        tags = formula.bottle_specification.collector.tags
+
+        tags.each do |tag|
+          test "brew", "fetch", "--retry", "--formulae", "--bottle-tag=#{tag}", formula_name
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to check that the built bottles can be fetched before
merging a PR.

Note: `--retry` does not actually work for `brew fetch` when fetching
bottles. This will need to be fixed in `brew`.
