### PR TITLE
Improve `#cleanup_during!`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -310,7 +310,7 @@ module Homebrew
       end
 
       def formula!(formula_name, args:)
-        cleanup_during!(args: args)
+        cleanup_during!(@testing_formulae, args: args)
 
         test_header(:Formulae, method: "formula!(#{formula_name})")
 

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -43,7 +43,7 @@ module Homebrew
       end
 
       def dependent_formulae!(formula_name, args:)
-        cleanup_during!(args: args)
+        cleanup_during!(@dependent_testing_formulae, args: args)
 
         test_header(:FormulaeDependents, method: "dependent_formulae!(#{formula_name})")
 
@@ -181,7 +181,7 @@ module Homebrew
           return
         end
 
-        cleanup_during!(args: args)
+        cleanup_during!(@dependent_testing_formulae, args: args)
 
         required_dependent_deps = dependent.deps.reject(&:optional?)
         bottled_on_current_version = bottled?(dependent, no_older_versions: true)


### PR DESCRIPTION
On some long-running CI runs, you can see multiple consecutive calls to
`#cleanup_during!` in the CI log. This indicates that the runner is
close to running out of space, but deleting `HOMEBREW_CACHE` isn't quite
going far enough in clearing it out.

Let's try to improve that by uninstalling installed formulae that are
safe to uninstall on the second call to `#cleanup_during!` onwards.
