### PR TITLE
formulae-detect: avoid erroring during `merge_group` events

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -140,7 +140,12 @@ module Homebrew
 
         @testing_formulae += @added_formulae + modified_formulae
 
-        if @testing_formulae.blank? && @deleted_formulae.blank? && diff_start_sha1 == diff_end_sha1
+        # TODO: Remove `GITHUB_EVENT_NAME` check when formulae detection
+        #       is fixed for merge groups.
+        if @testing_formulae.blank? &&
+           @deleted_formulae.blank? &&
+           diff_start_sha1 == diff_end_sha1 &&
+           (ENV["GITHUB_EVENT_NAME"] != "merge_group")
           raise UsageError, "Did not find any formulae or commits to test!"
         end
 


### PR DESCRIPTION
This will allow us to run `--only-formulae-detect` during a
`merge_group` event without producing an error.

Detecting formulae this way doesn't work for merge groups yet, but this
should allow us to test tweaks to formulae detection without making CI
throw errors all the time.
