### PR TITLE
formulae-detect: fix merge group detection

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -71,6 +71,11 @@ module Homebrew
             origin_ref = "origin/#{base_ref}"
             diff_start_sha1 = rev_parse(origin_ref)
             diff_end_sha1 = github_sha
+          # Use GitHub Actions variables for merge group jobs.
+          elsif ENV.fetch("GITHUB_EVENT_NAME", nil) == "merge_group"
+            origin_ref = "origin/#{github_ref.gsub(%r{^refs/heads/}, "")}"
+            diff_end_sha1 = github_sha
+            diff_start_sha1 = rev_parse("#{github_sha}^")
           # Use GitHub Actions variables for branch jobs.
           else
             test git, "-C", repository, "fetch", "origin", "+#{github_ref}" unless tap.official?

--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -74,8 +74,8 @@ module Homebrew
           # Use GitHub Actions variables for merge group jobs.
           elsif ENV.fetch("GITHUB_EVENT_NAME", nil) == "merge_group"
             origin_ref = "origin/#{github_ref.gsub(%r{^refs/heads/}, "")}"
+            diff_start_sha1 = rev_parse(origin_ref)
             diff_end_sha1 = github_sha
-            diff_start_sha1 = rev_parse("#{github_sha}^")
           # Use GitHub Actions variables for branch jobs.
           else
             test git, "-C", repository, "fetch", "origin", "+#{github_ref}" unless tap.official?


### PR DESCRIPTION
This should allow `--only-formulae-detect` to work inside a merge group.

We probably also want to merge #905 so we can test this properly.
