### PR TITLE
formulae_detect: use the first parent of `GITHUB_SHA`

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -74,7 +74,7 @@ module Homebrew
           # Use GitHub Actions variables for merge group jobs.
           elsif ENV.fetch("GITHUB_EVENT_NAME", nil) == "merge_group"
             origin_ref = "origin/#{github_ref.gsub(%r{^refs/heads/}, "")}"
-            diff_start_sha1 = rev_parse(origin_ref)
+            diff_start_sha1 = rev_parse("#{github_sha}^")
             diff_end_sha1 = github_sha
           # Use GitHub Actions variables for branch jobs.
           else


### PR DESCRIPTION
Unfortunately, `GITHUB_SHA` is the same as `origin/master` inside a
merge group, so we end up with `diff_start_sha1` and `diff_end_sha1`
pointing to the same (merge) commit.

See, for example: https://github.com/Homebrew/homebrew-core/commit/2ad18dc7fd2da5dde6956d0f8ceef4ff934bde06
