### PR TITLE
formulae_detect: actually use `origin/master` for starting SHA1

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -73,8 +73,8 @@ module Homebrew
             diff_end_sha1 = github_sha
           # Use GitHub Actions variables for merge group jobs.
           elsif ENV.fetch("GITHUB_EVENT_NAME", nil) == "merge_group"
-            origin_ref = "origin/#{github_ref.gsub(%r{^refs/heads/}, "")}"
             diff_start_sha1 = rev_parse(origin_ref)
+            origin_ref = "origin/#{github_ref.gsub(%r{^refs/heads/}, "")}"
             diff_end_sha1 = github_sha
           # Use GitHub Actions variables for branch jobs.
           else


### PR DESCRIPTION
Here, `origin_ref` points to the temporary merge group branch, so it
will be the same as `GITHUB_SHA`.
