### PR TITLE
formulae: skip formulae with failing bottle steps

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -190,7 +190,7 @@ module Homebrew
 
         bottle_step = steps.last
         if !bottle_step.passed? || !bottle_step.output?
-          skipped formula.full_name, "bottling failed"
+          failed formula.full_name, "bottling failed"
           return
         end
 

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -189,8 +189,10 @@ module Homebrew
         test "brew", "bottle", *bottle_args
 
         bottle_step = steps.last
-        return unless bottle_step.passed?
-        return unless bottle_step.output?
+        if !bottle_step.passed? || !bottle_step.output?
+          skipped formula.full_name, "bottling failed"
+          return
+        end
 
         @bottle_output_path.write(bottle_step.output, mode: "a")
 


### PR DESCRIPTION
If the bottle step fails, these should be added to
`skipped_or_failed_formulae` so we don't attempt to test them later.
