### PR TITLE
formulae: use strict audit

### DIFF
--- a/Formula/t/testbottest.rb
+++ b/Formula/t/testbottest.rb
@@ -6,7 +6,7 @@ class Testbottest < Formula
   url "file://#{Tap.fetch("homebrew", "test-bot").formula_dir}/t/tarballs/testbottest-0.1.tbz"
   sha256 "246c4839624d0b97338ce976100d56bd9331d9416e178eb0f74ef050c1dbdaad"
   license "BSD-2-Clause"
-  head "https://github.com/Homebrew/homebrew-test-bot.git"
+  head "https://github.com/Homebrew/homebrew-test-bot.git", branch: "master"
 
   depends_on xcode: ["10.2", :optional]
 

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -374,6 +374,7 @@ module Homebrew
         fetch_args << "--force" if args.cleanup?
 
         audit_args = [formula_name]
+        audit_args << "--strict"
         audit_args << "--online" unless skip_online_checks
         if new_formula
           audit_args << "--new-formula"


### PR DESCRIPTION
Since we are already requesting `Homebrew/core` contributors to use `brew audit --strict` (it's in the checklist), I believe our test bot should do the same.

This should help us, for instance, to notice the missing `test` block in Homebrew/homebrew-core#129122.