### PR TITLE
bottles_fetch: run `#cleanup_during!`

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -88,7 +88,7 @@ module Homebrew
         unsatisfied_requirements.values.flatten.map(&:message).join("\n").presence
       end
 
-      def cleanup_during!(keep_formulae, args:)
+      def cleanup_during!(keep_formulae = [], args:)
         return unless args.cleanup?
         return unless HOMEBREW_CACHE.exist?
 

--- a/lib/tests/bottles_fetch.rb
+++ b/lib/tests/bottles_fetch.rb
@@ -19,6 +19,10 @@ module Homebrew
       private
 
       def fetch_bottles!(formula_name, args:)
+        cleanup_during!(args: args)
+
+        test_header(:BottlesFetch, method: "fetch_bottles!(#{formula_name})")
+
         formula = Formula[formula_name]
         tags = formula.bottle_specification.collector.tags
 


### PR DESCRIPTION
This will help the runner avoid running out of memory when fetching
bottles. Likely needed for Homebrew/homebrew-core#118902.

Also, let's call `test_header` for consistency with other classes here.
