### PR TITLE
cleanup_before: clean `/Library/Frameworks` directory

### DIFF
--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -29,15 +29,24 @@ module Homebrew
 
     # Moving files is faster than removing them,
     # so move them if the current runner is ephemeral.
-    def delete_or_move(paths)
+    def delete_or_move(paths, sudo: false)
       return if paths.blank?
 
       symlinks, paths = paths.partition(&:symlink?)
 
       FileUtils.rm_f symlinks
+      paths.select!(&:exist?)
+
+      return if paths.blank?
 
       if ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
-        FileUtils.mv paths, Dir.mktmpdir, force: true
+        if sudo
+          test "sudo", "mv", *paths, Dir.mktmpdir
+        else
+          FileUtils.mv paths, Dir.mktmpdir, force: true
+        end
+      elsif sudo
+        test "sudo", "rm", "-rf", *paths
       else
         FileUtils.rm_rf paths
       end

--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -35,20 +35,21 @@ module Homebrew
       symlinks, paths = paths.partition(&:symlink?)
 
       FileUtils.rm_f symlinks
-      paths.select!(&:exist?)
+      return if ENV["HOMEBREW_GITHUB_ACTIONS"].blank?
 
+      paths.select!(&:exist?)
       return if paths.blank?
 
-      if ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
+      if ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].present?
         if sudo
-          test "sudo", "mv", *paths, Dir.mktmpdir
+          test "sudo", "rm", "-rf", *paths
         else
-          FileUtils.mv paths, Dir.mktmpdir, force: true
+          FileUtils.rm_rf paths
         end
       elsif sudo
-        test "sudo", "rm", "-rf", *paths
+        test "sudo", "mv", *paths, Dir.mktmpdir
       else
-        FileUtils.rm_rf paths
+        FileUtils.mv paths, Dir.mktmpdir, force: true
       end
     end
 

--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -16,17 +16,17 @@ module Homebrew
           # minimally fix brew doctor failures (a full clean takes ~5m)
           if OS.linux?
             # brew doctor complains
-            %w[
+            bad_paths = %w[
               /usr/local/include/node/
               /opt/pipx_bin/ansible-config
-            ].each do |path|
-              test "sudo", "mv", path, "/tmp" if File.exist?(path)
-            end
+            ].map { |path| Pathname.new(path) }
+
+            delete_or_move bad_paths, sudo: true
           elsif OS.mac?
-            delete_or_move Pathname.glob(HOMEBREW_CELLAR/"*")
+            delete_or_move HOMEBREW_CELLAR.glob("*")
 
             frameworks_dir = Pathname("/Library/Frameworks")
-            %w[
+            frameworks = %w[
               Mono.framework
               PluginManager.framework
               Python.framework
@@ -34,10 +34,9 @@ module Homebrew
               Xamarin.Android.framework
               Xamarin.Mac.framework
               Xamarin.iOS.framework
-            ].each do |framework|
-              path = frameworks_dir/framework
-              test "sudo", "mv", path, HOMEBREW_TEMP if path.exist?
-            end
+            ].map { |framework| frameworks_dir/framework }
+
+            delete_or_move frameworks, sudo: true
           end
         end
 

--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -24,6 +24,20 @@ module Homebrew
             end
           elsif OS.mac?
             delete_or_move Pathname.glob(HOMEBREW_CELLAR/"*")
+
+            frameworks_dir = Pathname("/Library/Frameworks")
+            %w[
+              Mono.framework
+              PluginManager.framework
+              Python.framework
+              R.framework
+              Xamarin.Android.framework
+              Xamarin.Mac.framework
+              Xamarin.iOS.framework
+            ].each do |framework|
+              path = frameworks_dir/framework
+              test "sudo", "mv", path, HOMEBREW_TEMP if path.exist?
+            end
           end
         end
 


### PR DESCRIPTION
These directories contain headers and libraries that we don't want to
use, so let's get rid of them when building on a GitHub macOS runner.

The Mono framework in particular contains Gettext headers that I've seen
mess up CMake builds in the past.
