### PR TITLE
cmd/test-bot: always set `--local` in GitHub Actions

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -109,13 +109,10 @@ module Homebrew
   end
 
   def setup_argv_and_env
-    github_actions = ENV["GITHUB_ACTIONS"].present?
-    if github_actions
-      ARGV << "--cleanup"
-      ENV["HOMEBREW_COLOR"] = "1"
-      ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
-    end
+    return if ENV["GITHUB_ACTIONS"].blank? && ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].blank?
 
-    ARGV << "--local" if ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].present?
+    ARGV << "--cleanup" << "--local"
+    ENV["HOMEBREW_COLOR"] = "1"
+    ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
   end
 end


### PR DESCRIPTION
Passing `--local` depending on whether the runner is self-hosted or not
complicates our handling of log directories in Homebrew/core.

Always setting it ensures that we can always look in the same place
relative to the bottles directory for the logs, and will allow us to
simplify some code in our workflows.

This also fix log uploads when using GitHub macOS runners for testing.
