### PR TITLE
tests/formulae: skip formulae with no bottles to build

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -363,7 +363,8 @@ module Homebrew
             onoe "Not building a bottle for #{formula} because it has unbottled dependencies."
           end
 
-          "--build-from-source"
+          skipped formula_name, "No bottle built."
+          return
         end
 
         # Online checks are a bit flaky and less useful for PRs that modify multiple formulae.


### PR DESCRIPTION
This will help us save CI time, and fixes an error in dependent testing
when we try to install a bottle that we never built.
