### PR TITLE
tests/formulae: download bottles from previous CI runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
+    permissions:
+      contents: read
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -48,11 +50,23 @@ jobs:
 
       - name: Build Docker image and start container
         if: matrix.os == 'ubuntu-latest'
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker build -t brew .
           docker create \
-            -e GITHUB_ACTIONS -e GITHUB_BASE_REF -e GITHUB_OUTPUT -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_SHA \
+            -e GITHUB_ACTIONS \
+            -e GITHUB_BASE_REF \
+            -e GITHUB_EVENT_PATH \
+            -e GITHUB_OUTPUT \
+            -e GITHUB_REF \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_SHA \
+            -e HOMEBREW_DEBUG \
+            -e HOMEBREW_GITHUB_API_TOKEN \
+            -e HOMEBREW_VERBOSE \
             -v "$GITHUB_OUTPUT:$GITHUB_OUTPUT" \
+            -v "$GITHUB_EVENT_PATH:$GITHUB_EVENT_PATH" \
             --name=brewtestbot brew sleep infinity
           docker start brewtestbot
           docker exec brewtestbot \
@@ -63,6 +77,8 @@ jobs:
 
       - name: Run brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
         id: brew-test-bot-formulae
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             docker exec brewtestbot \
@@ -115,6 +131,8 @@ jobs:
           fi
 
       - name: Run brew test-bot testbottest --only-formulae --dry-run
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             docker exec brewtestbot \

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -13,12 +13,12 @@ module Homebrew
 
       protected
 
-      def bottle_glob(formula_name)
-        Pathname.glob("#{formula_name}--*.#{Utils::Bottles.tag}.bottle*.tar.gz")
+      def bottle_glob(formula_name, bottle_dir, ext = ".tar.gz")
+        bottle_dir.glob("#{formula_name}--*.#{Utils::Bottles.tag}.bottle*#{ext}")
       end
 
-      def install_formula_from_bottle(formula_name, testing_formulae_dependents:, dry_run:)
-        bottle_filename = bottle_glob(formula_name).first
+      def install_formula_from_bottle(formula_name, testing_formulae_dependents:, dry_run:, bottle_dir: Pathname.pwd)
+        bottle_filename = bottle_glob(formula_name, bottle_dir).first
         if bottle_filename.blank?
           if testing_formulae_dependents && !dry_run
             raise "Failed to find bottle for '#{formula_name}'."

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -33,7 +33,9 @@ module Homebrew
         install_args += %w[--ignore-dependencies --skip-post-install] if testing_formulae_dependents
         test "brew", "install", *install_args, bottle_filename
         install_step = steps.last
-        test "brew", "unlink", formula_name if testing_formulae_dependents
+        return install_step.passed? unless testing_formulae_dependents
+
+        test "brew", "unlink", formula_name
         puts
 
         install_step.passed?

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -13,8 +13,12 @@ module Homebrew
 
       protected
 
+      def bottle_glob(formula_name)
+        Pathname.glob("#{formula_name}--*.#{Utils::Bottles.tag}.bottle*.tar.gz")
+      end
+
       def install_formula_from_bottle(formula_name, testing_formulae_dependents:, dry_run:)
-        bottle_filename = Dir.glob("#{formula_name}--*.#{Utils::Bottles.tag}.bottle*.tar.gz").first
+        bottle_filename = bottle_glob(formula_name).first
         if bottle_filename.blank?
           if testing_formulae_dependents && !dry_run
             raise "Failed to find bottle for '#{formula_name}'."

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "utils/github/artifacts"
+
 module Homebrew
   module Tests
     class Formulae < TestFormulae

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -535,6 +535,9 @@ module Homebrew
                                       testing_formulae_dependents: false,
                                       dry_run:                     args.dry_run?)
 
+        # Delete bottles that are stale or have install failures.
+        bottle_glob(formula_name).map(&:unlink) unless formula_installed_from_bottle
+
         install_step_passed ||= begin
           test "brew", "install", *install_args,
                named_args:      formula_name,

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -48,7 +48,7 @@ module Homebrew
           event_path = ENV.fetch("GITHUB_EVENT_PATH")
           event_payload = JSON.parse(File.read(event_path))
 
-          before = event_payload.fetch("before", nil)
+          before = event_payload.fetch("before", "")
           test git, "-C", repository, "fetch", "origin", before if before.present?
 
           before
@@ -104,7 +104,7 @@ module Homebrew
           next false if workflow_run.dig("workflow", "name") != "CI"
 
           check_run_nodes = node.dig("checkRuns", "nodes")
-          next false if check_suite_nodes.blank?
+          next false if check_run_nodes.blank?
 
           check_run_nodes.any? do |check_run_node|
             check_run_node.fetch("name") == "conclusion" && check_run_node.fetch("status") == "COMPLETED"
@@ -129,7 +129,7 @@ module Homebrew
 
       def no_diff?(formula, sha)
         relative_formula_path = formula.path.relative_path_from(repository)
-        system(git, "-C", repository, "diff", "--quiet", sha, relative_formula_path)
+        system(git, "-C", repository, "diff", "--no-ext-diff", "--quiet", sha, relative_formula_path)
       end
 
       def install_previously_built_bottle?(formula)

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -29,16 +29,7 @@ module Homebrew
           formula = Formulary.factory(formula_name)
           next if formula.latest_version_installed?
 
-          bottle_filename = Dir.glob("#{formula_name}--*.#{Utils::Bottles.tag}.bottle*.tar.gz").first
-          if bottle_filename.blank?
-            raise "Failed to find bottle for '#{formula_name}'." unless args.dry_run?
-
-            bottle_filename = "$BOTTLE_FILENAME"
-          end
-
-          test "brew", "install", "--ignore-dependencies", "--skip-post-install", bottle_filename
-          test "brew", "unlink", formula_name
-          puts
+          install_formula_from_bottle(formula_name, testing_formulae_dependents: true, dry_run: args.dry_run?)
         end
       end
 

--- a/spec/stub/utils/github/artifacts.rb
+++ b/spec/stub/utils/github/artifacts.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# Intentionally empty for no-op require.


### PR DESCRIPTION
This allows us to limit having to rebuild bottles that have already been
successfully built earlier.

~TODO: Actually install the downloaded bottles. Also needs
Homebrew/brew#15440 and Homebrew/brew#15441.~