### PR TITLE
formulae: ignore API authentication failures when downloading bottles

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -135,6 +135,8 @@ module Homebrew
         @previously_built_bottle_cache.cd do
           GitHub.download_artifact(download_url, run_id)
         end
+      rescue GitHub::API::AuthenticationFailedError => e
+        opoo e
       end
 
       def no_diff?(formula, sha)


### PR DESCRIPTION
The most likely cause for this is use in a repo that isn't
Homebrew/core. See, for example, Homebrew/brew#15485.

Closes Homebrew/brew#15486.
