### PR TITLE
tests/formulae: do not call `failed` in a dry run

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -302,7 +302,7 @@ module Homebrew
 
         bottle_step = steps.last
         if !bottle_step.passed? || !bottle_step.output?
-          failed formula.full_name, "bottling failed"
+          failed formula.full_name, "bottling failed" unless args.dry_run?
           return
         end
 


### PR DESCRIPTION
Returning early from `bottle_reinstall_formula` is expected for a dry
run.
