### PR TITLE
tests/formulae: fix Homebrew/brew tests (again)

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -53,10 +53,20 @@ module Homebrew
           event_path = ENV.fetch("GITHUB_EVENT_PATH")
           event_payload = JSON.parse(File.read(event_path))
 
+          repository_data = event_payload.fetch("repository")
+          owner = repository_data.dig("owner", "login")
+          repo = repository_data.fetch("name")
           before = event_payload.fetch("before", "")
-          test git, "-C", repository, "fetch", "origin", before if before.present? && repository.directory?
 
-          before
+          if before.present? &&
+             repository.directory? &&
+             tap.full_name == "#{owner}/#{repo}"
+            test git, "-C", repository, "fetch", "origin", before
+
+            before
+          else
+            ""
+          end
         end
 
         @previous_sha


### PR DESCRIPTION
`before` will be a SHA1 for Homebrew/brew, but `repository` points to
`Homebrew/core`, so trying to fetch that SHA1 will always fail in
Homebrew/brew.
