### PR TITLE
test_formulae: improve result caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,7 @@ jobs:
 
       - run: brew test-bot --only-cleanup-after
 
-      - run: rm -rvf *.bottle*.tar.gz
+      - run: rm -rvf *.bottle*.{json,tar.gz}
 
       - run: brew test-bot --only-setup --dry-run
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,8 +97,6 @@ jobs:
         id: formulae-detect
 
       - id: brew-test-bot-formulae
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           brew test-bot \
             --only-formulae \
@@ -106,11 +104,15 @@ jobs:
             --only-json-tab \
             --skip-dependents \
             --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: |
           brew test-bot --only-formulae-dependents --junit \
                         --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }} \
                         --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output brew test-bot failures
         run: |

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -17,7 +17,7 @@ module Homebrew
       @ignore_failures = ignore_failures
       @repository = repository
 
-      @name = command[1].delete("-")
+      @name = command[1]&.delete("-")
       @status = :running
       @output = nil
     end

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -29,7 +29,9 @@ module Homebrew
 
         github_event_payload = JSON.parse(File.read(github_event_path))
         head_repo_owner = github_event_payload.dig("pull_request", "head", "repo", "owner", "login")
-        return if head_repo_owner != ENV.fetch("GITHUB_REPOSITORY_OWNER")
+        head_from_fork = head_repo_owner != ENV.fetch("GITHUB_REPOSITORY_OWNER")
+        maintainer_fork = JSON.parse(HOMEBREW_MAINTAINER_JSON.read).include?(head_repo_owner)
+        return if head_from_fork && !maintainer_fork
 
         event_payload = JSON.parse(cached_event_json.read) if cached_event_json.present?
         event_payload ||= github_event_payload

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -143,8 +143,8 @@ module Homebrew
 
         @fetched_refs ||= []
         if @fetched_refs.exclude?(git_ref)
-          test git, "-C", repository, "fetch", "origin", git_ref
-          @fetched_refs << git_ref
+          test git, "-C", repository, "fetch", "origin", git_ref, ignore_failures: true
+          @fetched_refs << git_ref if steps.last.passed?
         end
 
         relative_formula_path = formula.path.relative_path_from(repository)

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -69,7 +69,7 @@ module Homebrew
         }
       GRAPHQL
 
-      def artifact_metadata(check_suite_nodes, event_name, workflow_name, check_run_name, artifact_name)
+      def artifact_metadata(check_suite_nodes, repo, event_name, workflow_name, check_run_name, artifact_name)
         candidate_nodes = check_suite_nodes.select do |node|
           next false if node.fetch("status") != "COMPLETED"
 
@@ -110,10 +110,11 @@ module Homebrew
         check_suite_nodes = response.dig("node", "checkSuites", "nodes")
         return if check_suite_nodes.blank?
 
-        wanted_artifact = artifact_metadata(check_suite_nodes, "pull_request", "CI", "conclusion", artifact_name)
+        wanted_artifact = artifact_metadata(check_suite_nodes, repo, "pull_request",
+                                            "CI", "conclusion", artifact_name)
         # If we didn't find the artifact that we wanted, fall back to the `event_payload` artifact.
-        wanted_artifact ||= artifact_metadata(check_suite_nodes, "pull_request_target", "Triage tasks",
-                                              "upload-metadata", "event_payload")
+        wanted_artifact ||= artifact_metadata(check_suite_nodes, repo, "pull_request_target",
+                                              "Triage tasks", "upload-metadata", "event_payload")
         return if wanted_artifact.blank?
 
         wanted_artifact_name = wanted_artifact.fetch("name")

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -148,7 +148,7 @@ module Homebrew
         end
 
         relative_formula_path = formula.path.relative_path_from(repository)
-        system(git, "-C", repository, "diff", "--no-ext-diff", "--quiet", git_ref, relative_formula_path)
+        system(git, "-C", repository, "diff", "--no-ext-diff", "--quiet", git_ref, "--", relative_formula_path)
       end
 
       def artifact_cache_valid?(formula)

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -30,7 +30,7 @@ module Homebrew
         github_event_payload = JSON.parse(File.read(github_event_path))
         head_repo_owner = github_event_payload.dig("pull_request", "head", "repo", "owner", "login")
         head_from_fork = head_repo_owner != ENV.fetch("GITHUB_REPOSITORY_OWNER")
-        maintainer_fork = JSON.parse(HOMEBREW_MAINTAINER_JSON.read).include?(head_repo_owner)
+        maintainer_fork = tap.official? && JSON.parse(HOMEBREW_MAINTAINER_JSON.read).include?(head_repo_owner)
         return if head_from_fork && !maintainer_fork
 
         # If we have a cached event payload, then we failed to get the artifact we wanted

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -28,7 +28,8 @@ module Homebrew
         return if (github_event_path = ENV.fetch("GITHUB_EVENT_PATH", nil)).blank?
 
         github_event_payload = JSON.parse(File.read(github_event_path))
-        return if github_event_payload.dig("pull_request", "head", "repo", "owner", "login") != "Homebrew"
+        head_repo_owner = github_event_payload.dig("pull_request", "head", "repo", "owner", "login")
+        return if head_repo_owner != ENV.fetch("GITHUB_REPOSITORY_OWNER")
 
         event_payload = JSON.parse(cached_event_json.read) if cached_event_json.present?
         event_payload ||= github_event_payload

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -154,7 +154,7 @@ module Homebrew
       def git_revision_from_local_bottle_json(formula)
         return if (local_bottle_json = bottle_glob(formula, artifact_cache, ".json").first).blank?
 
-        local_bottle_hash = JSON.parse(local_bottle_json)
+        local_bottle_hash = JSON.parse(local_bottle_json.read)
         local_bottle_hash.dig(formula.name, "formula", "tap_git_revision")
       end
 

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -24,7 +24,9 @@ module Homebrew
           download_artifact_from_previous_run!("bottles")
         end
         @bottle_checksums.merge!(
-          bottle_glob("*", artifact_cache, bottle_tag: "*").to_h { |bottle| [bottle.realpath, bottle.sha256] },
+          bottle_glob("*", artifact_cache, ".{json,tar.gz}", bottle_tag: "*").to_h do |bottle_file|
+            [bottle_file.realpath, bottle_file.sha256]
+          end,
         )
 
         # #run! modifies `@testing_formulae`, so we need to track this separately.
@@ -186,7 +188,8 @@ module Homebrew
           missing_bottles = @bottle_checksums.keys.reject do |bottle_path|
             next true if bottle_path.exist?
 
-            onoe "Missing bottle: #{bottle_path}"
+            what = (bottle_path.extname == ".json") ? "JSON" : "tarball"
+            onoe "Missing bottle #{what}: #{bottle_path}"
             false
           end
 
@@ -202,10 +205,13 @@ module Homebrew
             false
           end
 
-          unexpected_bottles = bottle_glob("**/*", bottle_tag: "*").reject do |local_bottle|
+          unexpected_bottles = bottle_glob(
+            "**/*", Pathname.pwd, ".{json,tar.gz}", bottle_tag: "*"
+          ).reject do |local_bottle|
             next true if @bottle_checksums.key?(local_bottle.realpath)
 
-            onoe "Unexpected bottle: #{local_bottle}"
+            what = (local_bottle.extname == ".json") ? "JSON" : "tarball"
+            onoe "Unexpected bottle #{what}: #{local_bottle}"
             false
           end
 
@@ -257,10 +263,12 @@ module Homebrew
           bottle_step.output
                      .gsub(%r{.*(\./\S+#{HOMEBREW_BOTTLES_EXTNAME_REGEX}).*}om, '\1'),
         )
-        @bottle_checksums[@bottle_filename.realpath] = @bottle_filename.sha256
+        @bottle_json_filename = Pathname.new(
+          @bottle_filename.to_s.gsub(/\.(\d+\.)?tar\.gz$/, ".json"),
+        )
 
-        @bottle_json_filename =
-          @bottle_filename.to_s.gsub(/\.(\d+\.)?tar\.gz$/, ".json")
+        @bottle_checksums[@bottle_filename.realpath] = @bottle_filename.sha256
+        @bottle_checksums[@bottle_json_filename.realpath] = @bottle_json_filename.sha256
 
         @bottle_output_path.write(bottle_step.output, mode: "a")
 
@@ -271,7 +279,7 @@ module Homebrew
         test "brew", "bottle", *bottle_merge_args
         test "brew", "uninstall", "--force", formula.full_name
 
-        bottle_json = JSON.parse(File.read(@bottle_json_filename))
+        bottle_json = JSON.parse(@bottle_json_filename.read)
         root_url = bottle_json.dig(formula.full_name, "bottle", "root_url")
         filename = bottle_json.dig(formula.full_name, "bottle", "tags").values.first["filename"]
 
@@ -518,14 +526,13 @@ module Homebrew
         end
 
         if formula_installed_from_bottle
-          moved_artifacts = bottle_glob(formula_name, artifact_cache, ".{json,tar.gz}")
+          moved_artifacts = bottle_glob(formula_name, artifact_cache, ".{json,tar.gz}").map(&:realpath)
           Pathname.pwd.install moved_artifacts
 
-          moved_artifacts.each do |artifact|
-            next if artifact.extname == ".json"
-
-            @bottle_checksums[artifact.basename.realpath] = @bottle_checksums.fetch(artifact)
-            @bottle_checksums.delete(artifact)
+          moved_artifacts.each do |old_location|
+            new_location = old_location.basename.realpath
+            @bottle_checksums[new_location] = @bottle_checksums.fetch(old_location)
+            @bottle_checksums.delete(old_location)
           end
         else
           bottle_reinstall_formula(formula, new_formula, args: args)
@@ -565,11 +572,15 @@ module Homebrew
         # Move bottle and don't test dependents if the formula linkage or test failed.
         if failed_linkage_or_test_messages.present?
           if @bottle_filename
-            failed_dir = (@bottle_filename.dirname/"failed").mkpath
-            FileUtils.mv [@bottle_filename, @bottle_json_filename], failed_dir
-            @bottle_checksums[(failed_dir/@bottle_filename.basename).realpath] =
-              @bottle_checksums.fetch(@bottle_filename)
-            @bottle_checksums.delete(@bottle_filename)
+            failed_dir = @bottle_filename.dirname/"failed"
+            moved_artifacts = [@bottle_filename, @bottle_json_filename].map(&:realpath)
+            failed_dir.install moved_artifacts
+
+            moved_artifacts.each do |old_location|
+              new_location = (failed_dir/old_location.basename).realpath
+              @bottle_checksums[new_location] = @bottle_checksums.fetch(old_location)
+              @bottle_checksums.delete(old_location)
+            end
           end
 
           if ignore_failures

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -222,7 +222,7 @@ module Homebrew
           files_to_delete += files_to_delete.select(&:symlink?).map(&:realpath)
           FileUtils.rm_rf files_to_delete
 
-          exit 1
+          test "false" # ensure that `test-bot` exits with an error.
         end
       end
 

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -169,10 +169,11 @@ module Homebrew
       end
 
       def install_dependent(dependent, testable_dependents, args:, build_from_source: false)
-        if @skip_candidates.include?(dependent.full_name) && artifact_cache_valid?(dependent)
+        if @skip_candidates.include?(dependent.full_name) &&
+           artifact_cache_valid?(dependent, formulae_dependents: true)
           @tested_dependents_list.write(dependent.full_name, mode: "a")
           @tested_dependents_list.write("\n", mode: "a")
-          skipped dependent.name, "#{dependent.full_name} has been tested at #{previous_github_sha}!"
+          skipped dependent.name, "#{dependent.full_name} has been tested at #{previous_github_sha}"
           return
         end
 


### PR DESCRIPTION
Our current method of using artifacts as a cache breaks when a PR is
pushed to multiple times in quick succession.

This is because we use the SHA1 prior to the most recent push to look up
artifacts, but there will be no useable artifacts to find there after
pushing to a PR that has recently been pushed to.

We can improve this by looking for an even earlier SHA1 to try to find
useable artifacts from.

This is a companion to Homebrew/homebrew-core#132093.
