### PR TITLE
Reduce attempts to download artifact cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,8 +111,6 @@ jobs:
           brew test-bot --only-formulae-dependents --junit \
                         --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }} \
                         --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output brew test-bot failures
         run: |
@@ -131,5 +129,3 @@ jobs:
       - run: brew test-bot --only-setup --dry-run
 
       - run: brew test-bot testbottest --only-formulae --dry-run
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -103,7 +103,8 @@ module Homebrew
         artifacts.find { |artifact| artifact.fetch("name") == artifact_name }
       end
 
-      def download_artifact_from_previous_run!(artifact_name)
+      def download_artifact_from_previous_run!(artifact_name, dry_run:)
+        return if dry_run
         return if GitHub::API.credentials_type == :none
         return if (sha = previous_github_sha).blank?
 
@@ -145,7 +146,7 @@ module Homebrew
 
         # If we made it here, then we downloaded an `event_payload` artifact.
         # We can now use this `event_payload` artifact to attempt to download the artifact we wanted.
-        download_artifact_from_previous_run!(artifact_name)
+        download_artifact_from_previous_run!(artifact_name, dry_run: dry_run)
       rescue GitHub::API::AuthenticationFailedError => e
         opoo e
       end

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -104,6 +104,7 @@ module Homebrew
       end
 
       def download_artifact_from_previous_run!(artifact_name)
+        return if GitHub::API.credentials_type == :none
         return if (sha = previous_github_sha).blank?
 
         repo = ENV.fetch("GITHUB_REPOSITORY")

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -21,7 +21,7 @@ module Homebrew
         verify_local_bottles
 
         with_env(HOMEBREW_DISABLE_LOAD_FORMULA: "1") do
-          download_artifact_from_previous_run!("bottles")
+          download_artifact_from_previous_run!("bottles", dry_run: args.dry_run?)
         end
         @bottle_checksums.merge!(
           bottle_glob("*", artifact_cache, ".{json,tar.gz}", bottle_tag: "*").to_h do |bottle_file|

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -17,7 +17,7 @@ module Homebrew
 
         install_formulae_if_needed_from_bottles!(args: args)
 
-        download_artifact_from_previous_run!("dependents")
+        download_artifact_from_previous_run!("dependents", dry_run: args.dry_run?)
         @skip_candidates = if (tested_dependents_cache = artifact_cache/@tested_dependents_list).exist?
           tested_dependents_cache.read.split("\n")
         else


### PR DESCRIPTION
- Skip artifact download if there are no credentials
- Skip artifact download for dry runs

Without credentials, our attempts to download artifacts quickly hits the API rate limit.
