### PR TITLE
formulae: avoid fetching just-built dependencies

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -124,10 +124,9 @@ module Homebrew
         end
 
         info_header "Determining dependencies..."
-        installed = Utils.safe_popen_read("brew", "list", "--formula").split("\n")
+        installed = Utils.safe_popen_read("brew", "list", "--formula", "--full-name").split("\n")
         dependencies =
-          Utils.safe_popen_read("brew", "deps", "--include-build",
-                                "--include-test", formula_name)
+          Utils.safe_popen_read("brew", "deps", "--include-build", "--include-test", "--full-name", formula_name)
                .split("\n")
         installed_dependencies = installed & dependencies
         installed_dependencies.each do |name|


### PR DESCRIPTION
Trying to fetch a just-built dependency will result in a `brew fetch`
failure because its bottle will not have been uploaded yet.

See Homebrew/homebrew-core#133144.
