### PR TITLE
tests: improve no-API switching for named args

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -16,6 +16,8 @@ module Homebrew
       end
 
       def run!(args:)
+        test_header(:Formulae)
+
         verify_local_bottles
 
         with_env(HOMEBREW_DISABLE_LOAD_FORMULA: "1") do

--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -5,10 +5,9 @@ module Homebrew
     class TapSyntax < Test
       def run!(args:)
         test_header(:TapSyntax)
+        return unless tap.installed?
 
-        broken_xcode_rubygems = MacOS.version == :mojave &&
-                                MacOS.active_developer_dir == "/Applications/Xcode.app/Contents/Developer"
-        test "brew", "style", tap.name unless broken_xcode_rubygems
+        test "brew", "style", tap.name
 
         return if tap.formula_files.blank? && tap.cask_files.blank?
 


### PR DESCRIPTION
Everything in a CI environment worked ok. This is just small tweaks so that a `brew test-bot hello` on the command line switches to no-API mode.