### PR TITLE
Handle new uses_from_macos dependencies

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -250,7 +250,7 @@ module Homebrew
         # up the dep tree when we encounter an `:all` bottle because
         # a formula is not bottled unless its dependencies are.
         if formula.bottle_specification.tag?(Utils::Bottles.tag(:all))
-          formula.deps.all? { |dep| bottled?(dep.to_formula, no_older_versions: no_older_versions) }
+          formula.effective_deps.all? { |dep| bottled?(dep.to_formula, no_older_versions: no_older_versions) }
         else
           formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions: no_older_versions)
         end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -309,7 +309,7 @@ module Homebrew
       def build_bottle?(formula, args:)
         # Build and runtime dependencies must be bottled on the current OS,
         # but accept an older compatible bottle for test dependencies.
-        return false if formula.deps.any? do |dep|
+        return false if formula.effective_deps.any? do |dep|
           !bottled_or_built?(
             dep.to_formula,
             @built_formulae - @skipped_or_failed_formulae,
@@ -399,7 +399,7 @@ module Homebrew
 
         test "brew", "deps", "--tree", "--annotate", "--include-build", "--include-test", named_args: formula_name
 
-        deps_without_compatible_bottles = formula.deps.map(&:to_formula)
+        deps_without_compatible_bottles = formula.effective_deps.map(&:to_formula)
         deps_without_compatible_bottles.reject! do |dep|
           bottled_or_built?(dep, @built_formulae - @skipped_or_failed_formulae)
         end
@@ -476,7 +476,7 @@ module Homebrew
           return
         end
 
-        deps |= formula.deps.to_a.reject(&:optional?)
+        deps |= formula.effective_deps.to_a.reject(&:optional?)
         reqs |= formula.requirements.to_a.reject(&:optional?)
 
         tap_needed_taps(deps)


### PR DESCRIPTION
To be merged with https://github.com/Homebrew/brew/pull/15566.

The plan is to move uses_from_macos dependencies to live alongwith any other dependency. For test-bot however, we want to ignore uses_from_macos dependencies, so I've added an `effective_deps` method that mimics the old behaviour.