### PR TITLE
lib/test_bot: no environment hints.

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -60,6 +60,7 @@ module Homebrew
       ENV["HOMEBREW_CURL_PATH"] = "/usr/bin/curl"
       ENV["HOMEBREW_GIT_PATH"] = GIT
       ENV["HOMEBREW_DISALLOW_LIBNSL1"] = "1"
+      ENV["HOMEBREW_NO_ENV_HINTS"] = "1"
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
       # https://github.com/Homebrew/brew/issues/14274


### PR DESCRIPTION
These are just a bit annoying in `brew test-bot` output.