### PR TITLE
tests: speed up non-push/merge group cases.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -528,6 +528,7 @@ module Homebrew
 
         livecheck(formula) if !args.skip_livecheck? && !skip_online_checks
 
+        test "brew", "style", formula_name
         test "brew", "audit", *audit_args unless formula.deprecated?
         unless install_step_passed
           if ignore_failures

--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -9,15 +9,17 @@ module Homebrew
 
         test "brew", "style", tap.name
 
-        return if tap.formula_files.blank? && tap.cask_files.blank?
+        if tap.core_tap? || tap.core_cask_tap?
+          if %w[push merge_group].include?(ENV["GITHUB_EVENT_NAME"])
+            test "brew", "readall", "--aliases", tap.name
+            test "brew", "audit", "--tap=#{tap.name}"
+          end
 
-        test "brew", "readall", "--aliases", tap.name
-        test "brew", "audit", "--tap=#{tap.name}"
-
-        return if %w[push merge_group].exclude?(ENV["GITHUB_EVENT_NAME"])
-        return if !tap.core_tap? && !tap.name.start_with?("homebrew/cask")
-
-        test_api_generation
+          test_api_generation
+        elsif tap.formula_files.present? || tap.cask_files.present?
+          test "brew", "readall", "--aliases", tap.name
+          test "brew", "audit", "--tap=#{tap.name}"
+        end
       end
 
       private


### PR DESCRIPTION
- only run `readall` or `audit` on the whole tap for `push` and `merge_group` runs.
- always run `brew style` on the formula in case `tap_syntax` isn't run or there's macOS/Linux differences as it's really fast.