### PR TITLE
Improve dependent test ordering

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -614,46 +614,6 @@ module Homebrew
              "--include-test",
              formula_name
       end
-
-      def sorted_formulae
-        changed_formulae_dependents = {}
-
-        @testing_formulae.each do |formula|
-          begin
-            formula_dependencies =
-              Utils.popen_read("brew", "deps", "--full-name",
-                               "--include-build",
-                               "--include-test", formula)
-                   .split("\n")
-            # deps can fail if deps are not tapped
-            unless $CHILD_STATUS.success?
-              Formulary.factory(formula).recursive_dependencies
-              # If we haven't got a TapFormulaUnavailableError, then something else is broken
-              raise "Failed to determine dependencies for '#{formula}'."
-            end
-          rescue TapFormulaUnavailableError => e
-            raise if e.tap.installed?
-
-            e.tap.clear_cache
-            safe_system "brew", "tap", e.tap.name
-            retry
-          end
-
-          unchanged_dependencies = formula_dependencies - @testing_formulae
-          changed_dependencies = formula_dependencies - unchanged_dependencies
-          changed_dependencies.each do |changed_formula|
-            changed_formulae_dependents[changed_formula] ||= 0
-            changed_formulae_dependents[changed_formula] += 1
-          end
-        end
-
-        changed_formulae = changed_formulae_dependents.sort do |a1, a2|
-          a2[1].to_i <=> a1[1].to_i
-        end
-        changed_formulae.map!(&:first)
-        unchanged_formulae = @testing_formulae - changed_formulae
-        changed_formulae + unchanged_formulae
-      end
     end
   end
 end


### PR DESCRIPTION
This restores changes made in https://github.com/Homebrew/homebrew-test-bot/commit/fab38f1bfad42221f7af06a58ca72b62228f5eb6 that were lost in https://github.com/Homebrew/homebrew-test-bot/commit/cbe87b4b5a7ad44b70ea34d593c797b660db5f0d.

In summary, this PR:
* Changes the order of formulae we run dependent testing on to be the same order as the formulae were built. This means it's roughly topological now so the postinstalls will now be run in the correct order should one formula we're testing the dependents of is a dependency of another such formula.
* Dependents of multiple formulae will now be deferred as much as possible rather than eagerly tested when they're first encountered. This again ensures we're only testing things after all the relevant postinstalls have happened.

Should fix issues seen in https://github.com/Homebrew/homebrew-core/pull/141617.