### PR TITLE
Add os/arch options to readall command

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -11,13 +11,13 @@ module Homebrew
 
         if tap.core_tap? || tap.core_cask_tap?
           if %w[push merge_group].include?(ENV["GITHUB_EVENT_NAME"])
-            test "brew", "readall", "--aliases", tap.name
+            test "brew", "readall", "--aliases", "--os=all", "--arch=all", tap.name
             test "brew", "audit", "--tap=#{tap.name}"
           end
 
           test_api_generation
         elsif tap.formula_files.present? || tap.cask_files.present?
-          test "brew", "readall", "--aliases", tap.name
+          test "brew", "readall", "--aliases", "--os=all", "--arch=all", tap.name
           test "brew", "audit", "--tap=#{tap.name}"
         end
       end


### PR DESCRIPTION
This is a follow-up to changes that added os/arch combinations a few months ago. They were made the default temporarily until the references to `brew readall` in the other Homebrew repos were updated as well.

- https://github.com/Homebrew/brew/pull/15470
- https://github.com/Homebrew/brew/pull/15937#discussion_r1313889254