### PR TITLE
tests/setup: explicitly select gem groups

### DIFF
--- a/lib/tests/setup.rb
+++ b/lib/tests/setup.rb
@@ -6,7 +6,7 @@ module Homebrew
       def run!(args:)
         test_header(:Setup)
 
-        test "brew", "install-bundler-gems"
+        test "brew", "install-bundler-gems", "--add-groups=style,formula_test"
 
         # Always output `brew config` output even when it doesn't fail.
         test "brew", "config", verbose: true


### PR DESCRIPTION
This would get picked up eventually by `brew style`, but let's be explicit here so that the time spent is obvious.