### PR TITLE
tests/tap_syntax: simplify and speed up

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -9,32 +9,10 @@ module Homebrew
 
         test "brew", "style", tap.name
 
-        if tap.core_tap? || tap.core_cask_tap?
-          if %w[push merge_group].include?(ENV["GITHUB_EVENT_NAME"])
-            test "brew", "readall", "--aliases", "--os=all", "--arch=all", tap.name
-            test "brew", "audit", "--tap=#{tap.name}"
-          end
+        return if tap.formula_files.blank? && tap.cask_files.blank?
 
-          test_api_generation
-        elsif tap.formula_files.present? || tap.cask_files.present?
-          test "brew", "readall", "--aliases", "--os=all", "--arch=all", tap.name
-          test "brew", "audit", "--tap=#{tap.name}"
-        end
-      end
-
-      private
-
-      def test_api_generation
-        FileUtils.mkdir_p "api"
-        Pathname("api").cd do
-          if tap.core_tap?
-            test "brew", "generate-formula-api"
-          else
-            test "brew", "generate-cask-api"
-          end
-        end
-      ensure
-        FileUtils.rm_rf "api"
+        test "brew", "readall", "--aliases", "--os=all", "--arch=all", tap.name
+        test "brew", "audit", "--except=installed", "--tap=#{tap.name}"
       end
     end
   end


### PR DESCRIPTION
After perf and coverage improvments, we can simplify this for an overall speed boost.

I've also explicitly added a `--except=installed` here. It's not needed for most of our CI, but might be on `macos-latest`. The result of tap_syntax shouldn't be dependent on what formulae happen to be installed - these checks are best suited (and are run) on a per-formula basis in formula tests. We do not guarantee the speed of installed-formula audits, as it largely varies on how big formulae are and all our perf improvements haven't considered installed-formula audits.