### PR TITLE
Update rspec Ruby, Gemfile, actions/cache, etc.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   allow:
-  - dependency-type: direct
-  - dependency-type: indirect
+    - dependency-type: all
+  versioning-strategy: lockfile-only
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,32 +19,11 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
-
-      - run: brew test-bot --only-cleanup-before
-
-      - run: brew test-bot --only-setup
-
       - name: Set up Ruby
-        if: runner.os == 'Linux'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: "3.1"
           bundler-cache: true
-
-      - name: Install Homebrew/homebrew-test-bot RubyGems
-        if: runner.os == 'macOS'
-        run: bundle install --jobs 4 --retry 3
 
       - name: Run Homebrew/homebrew-test-bot RSpec tests
         run: bundle exec rspec
@@ -77,15 +56,11 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
-
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
 
       - run: brew test-bot --only-cleanup-before
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "activesupport", "< 7" # 7 requires Ruby 2.7
+  gem "activesupport"
   gem "rspec"
   gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.6)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.1.1)
+      ruby2_keywords
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     minitest (5.20.0)
+    mutex_m (0.1.2)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -26,6 +36,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
+    ruby2_keywords (0.0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -34,15 +45,14 @@ GEM
     simplecov_json_formatter (0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (< 7)
+  activesupport
   rspec
   simplecov
 
 BUNDLED WITH
-   1.17.3
+   2.4.10

--- a/lib/junit.rb
+++ b/lib/junit.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "rexml/document"
-require "rexml/xmldecl"
-require "rexml/cdata"
-
 module Homebrew
   # Creates Junit report with only required by BuildPulse attributes
   # See https://github.com/Homebrew/homebrew-test-bot/pull/621#discussion_r658712640
@@ -14,6 +10,10 @@ module Homebrew
 
     def build(filters: nil)
       filters ||= []
+
+      require "rexml/document"
+      require "rexml/xmldecl"
+      require "rexml/cdata"
 
       @xml_document = REXML::Document.new
       @xml_document << REXML::XMLDecl.new


### PR DESCRIPTION
We're moving away from 2.6 and the rspecs tests here don't _need_ to be running 2.6 still, particularly when we still have `brew test-bot` commands being run in the workflow which will be use Homebrew's Ruby. It might also give us an early warning of Ruby 3.1 issues, though the rspec test coverage here is extremely minimal.

Also update `actions/cache` to v3 since we support that now in setup-homebrew.