### PR TITLE
test_runner: scope JUnit output to only formula steps

### DIFF
--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -95,7 +95,7 @@ module Homebrew
       steps_output_path.unlink if steps_output_path.exist?
       steps_output_path.write(steps_output)
 
-      if args.junit?
+      if args.junit? && (no_only_args?(args) || args.only_formulae? || args.only_formulae_dependents?)
         junit_filters = %w[audit test]
         junit = ::Homebrew::Junit.new(tests)
         junit.build(filters: junit_filters)


### PR DESCRIPTION
REXML will not be available with Ruby 3 and JUnit output currently needs it. However, we only really need JUnit output when doing the formula steps (because we filter for `audit` and `test`), and formula steps assume that `brew test-bot --only-setup` has already been run with the `brew install-bundler-gems --groups=...` it internally does, so simply making sure it only is executed when running those steps should address the issue.