### PR TITLE
Gate `MacOS` calls behind `OS.mac?` conditionals

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -242,7 +242,7 @@ module Homebrew
 
         # This is needed where sparse files may be handled (bsdtar >=3.0).
         # We use gnu-tar with sparse files disabled when --only-json-tab is passed.
-        ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if MacOS.version >= :catalina && !args.only_json_tab?
+        ENV["HOMEBREW_BOTTLE_SUDO_PURGE"] = "1" if OS.mac? && MacOS.version >= :catalina && !args.only_json_tab?
 
         bottle_args = ["--verbose", "--json", formula.full_name]
         bottle_args << "--keep-old" if args.keep_old? && !new_formula


### PR DESCRIPTION
See https://github.com/Homebrew/brew/pull/16224

This PR makes it so that all references to the `MacOS` module are gates behind `OS.mac?` calls to allow the `MacOS` module to be deprecated on Linux.

My only outstanding question is whether this reference needs to be changed:

https://github.com/Homebrew/homebrew-test-bot/blob/9da1d1f7f4de703c517c22dbdc237725ed4cd5ac/spec/stub/os.rb#L3-L9

This is in the test directory so it shouldn't affect functionality, only CI in this repo.