### PR TITLE
Remove bottle cache hard linking

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -135,12 +135,6 @@ module Homebrew
                                   "1589480+BrewTestBot@users.noreply.github.com"
 
       Homebrew.failed = !TestRunner.run!(tap, git: GIT, args: args)
-    ensure
-      if HOMEBREW_CACHE.exist?
-        Dir.glob("*.bottle*.tar.gz") do |bottle_file|
-          FileUtils.rm_f HOMEBREW_CACHE/bottle_file
-        end
-      end
     end
   end
 end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -280,23 +280,6 @@ module Homebrew
         test "brew", "bottle", *bottle_merge_args
         test "brew", "uninstall", "--force", formula.full_name
 
-        bottle_json = JSON.parse(@bottle_json_filename.read)
-        root_url = bottle_json.dig(formula.full_name, "bottle", "root_url")
-        filename = bottle_json.dig(formula.full_name, "bottle", "tags").values.first["filename"]
-
-        # Test bottle is never uploaded, so we need to stub a cached download.
-        download_strategy = CurlGitHubPackagesDownloadStrategy.new(
-          "#{root_url}/#{filename}",
-          formula.name,
-          formula.version,
-        )
-        download_strategy.resolved_basename = @bottle_filename.basename.to_s
-        download_strategy.cached_location.parent.mkpath
-        FileUtils.ln @bottle_filename, download_strategy.cached_location, force: true
-        FileUtils.ln_s download_strategy.cached_location.relative_path_from(download_strategy.symlink_location),
-                       download_strategy.symlink_location,
-                       force: true
-
         @testing_formulae.delete(formula.name)
 
         unless @unchanged_build_dependencies.empty?


### PR DESCRIPTION
This is way too fragile and has broken multiple times before (it's why we have `/github/home` manually set as the working directory in a few places), including from changes like https://github.com/Homebrew/brew/pull/16245. It relies far too much on brew internals and we forgot to even update when switching to GitHub Packages until two years later. I'm not entirely sure how anyone even noticed in the end. It also has never supported manifest linking.

I'm not sure if it's even necessary anymore. The formulae intentionally stay installed so when would we be fetching it again? I'd like to try without this and see what breaks. If nothing: great. If there is something: I'd like to see if there's a better way to fix it as it might mean something is getting fetched unnecessarily.

The cleanup side of it was very outdated as well and wasn't working.