### PR TITLE
tests/formulae: use `--new` flag.

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -439,7 +439,7 @@ module Homebrew
         audit_args = [formula_name]
         audit_args << "--online" unless skip_online_checks
         if new_formula
-          audit_args << "--new-formula"
+          audit_args << "--new"
         else
           audit_args << "--git" << "--skip-style"
         end


### PR DESCRIPTION
`--new-formula` was deprecated in https://github.com/Homebrew/brew/pull/16306

Fixes https://github.com/Homebrew/homebrew-test-bot/issues/991