### PR TITLE
Add option to skip `stable_version` audit

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -59,6 +59,8 @@ module Homebrew
              description: "Don't test livecheck."
       switch "--skip-recursive-dependents",
              description: "Only test the direct dependents."
+      switch "--skip-stable-version-audit",
+             description: "Don't audit the stable version."
       switch "--only-cleanup-before",
              description: "Only run the pre-cleanup step. Needs `--cleanup`."
       switch "--only-setup",

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -438,6 +438,7 @@ module Homebrew
 
         audit_args = [formula_name]
         audit_args << "--online" unless skip_online_checks
+        audit_args << "--except=stable_version" if args.skip_stable_version_audit?
         if new_formula
           audit_args << "--new"
         else


### PR DESCRIPTION
I recently split the stable version formula audit into a separate method that can be skipped using `--except` (https://github.com/Homebrew/brew/pull/16335). This adds a `--skip-stable-version-audit` option to test-bot that passes `--except=stable_version` to `brew audit`. This will be controlled in homebrew/core using a `CI-version-downgrade` label (for when we need a downgrade PR to run on CI).

Alternatively, if we want something more general purpose, we could add an `--audit-except` (or `except-audit`) option instead. That could potentially save us from having to add additional options like this that simply skip an audit. The only catch is that we would have to make sure to collect the `except` args in CI workflows and only pass `--audit-except` once to test-bot.