### PR TITLE
test_formulae: allow disabling bottle cache with `CI-no-bottle-cache` label

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -166,8 +166,6 @@ module Homebrew
         download_artifact_from_previous_run!(artifact_name, dry_run: dry_run)
       rescue GitHub::API::AuthenticationFailedError => e
         opoo e
-      rescue LoadError # TODO: Remove when GitHub Actions is on Homebrew 4.0.19+.
-        nil
       end
 
       def no_diff?(formula, git_ref)

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -119,7 +119,8 @@ module Homebrew
         github_repository = ENV.fetch("GITHUB_REPOSITORY")
         owner, repo = *github_repository.split("/")
         pr_labels = GitHub.pull_request_labels(owner, repo, pull_number)
-        return if pr_labels.include?("workflows") # Avoid cache poisoning.
+        # Also disable bottle cache for PRs modifying workflows to avoid cache poisoning.
+        return if pr_labels.include?("CI-no-bottle-cache") || pr_labels.include?("workflows")
 
         variables = {
           owner:  owner,


### PR DESCRIPTION
As discussed internally in Slack, this allows us to disable bottle cache more intuitively.
