### PR TITLE
Fix `ignore_failures` usage with `--test-default-formula`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -540,7 +540,7 @@ module Homebrew
           # they can be unavoidable but we still want to know about them.
           test "brew", "linkage", "--cached", "--test", "--strict",
                named_args:      formula_name,
-               ignore_failures: !args.test_default_formula? && true
+               ignore_failures: !args.test_default_formula?
         end
 
         test "brew", "linkage", "--cached", formula_name

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -148,7 +148,7 @@ module Homebrew
           test "brew", "fetch", "--retry", "--build-from-source",
                *changed_dependencies
 
-          ignore_failures = changed_dependencies.any? do |dep|
+          ignore_failures = !args.test_default_formula? && changed_dependencies.any? do |dep|
             !bottled?(Formulary.factory(dep), no_older_versions: true)
           end
 
@@ -236,7 +236,7 @@ module Homebrew
         root_url = args.root_url
 
         # GitHub Releases url
-        root_url ||= if tap.present? && !tap.core_tap? && !@test_default_formula
+        root_url ||= if tap.present? && !tap.core_tap? && !args.test_default_formula?
           "#{tap.default_remote}/releases/download/#{formula.name}-#{formula.pkg_version}"
         end
 
@@ -247,7 +247,7 @@ module Homebrew
         bottle_args = ["--verbose", "--json", formula.full_name]
         bottle_args << "--keep-old" if args.keep_old? && !new_formula
         bottle_args << "--skip-relocation" if args.skip_relocation?
-        bottle_args << "--force-core-tap" if @test_default_formula
+        bottle_args << "--force-core-tap" if args.test_default_formula?
         bottle_args << "--root-url=#{root_url}" if root_url
         bottle_args << "--only-json-tab" if args.only_json_tab?
 
@@ -394,7 +394,7 @@ module Homebrew
         end
 
         new_formula = @added_formulae.include?(formula_name)
-        ignore_failures = !bottled_on_current_version && !new_formula
+        ignore_failures = !args.test_default_formula? && !bottled_on_current_version && !new_formula
 
         deps = []
         reqs = []
@@ -540,7 +540,7 @@ module Homebrew
           # they can be unavoidable but we still want to know about them.
           test "brew", "linkage", "--cached", "--test", "--strict",
                named_args:      formula_name,
-               ignore_failures: true
+               ignore_failures: !args.test_default_formula? && true
         end
 
         test "brew", "linkage", "--cached", formula_name

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -235,7 +235,7 @@ module Homebrew
           test "brew", "install", *build_args,
                named_args:      dependent.full_name,
                env:             env.merge({ "HOMEBREW_DEVELOPER" => nil }),
-               ignore_failures: build_from_source && !bottled_on_current_version
+               ignore_failures: !args.test_default_formula? && build_from_source && !bottled_on_current_version
           install_step = steps.last
 
           return unless install_step.passed?
@@ -249,7 +249,7 @@ module Homebrew
         test "brew", "install", "--only-dependencies", dependent.full_name
         test "brew", "linkage", "--test",
              named_args:      dependent.full_name,
-             ignore_failures: !bottled_on_current_version
+             ignore_failures: !args.test_default_formula? && !bottled_on_current_version
         linkage_step = steps.last
 
         if linkage_step.passed? && !build_from_source
@@ -257,7 +257,7 @@ module Homebrew
           # they can be unavoidable but we still want to know about them.
           test "brew", "linkage", "--cached", "--test", "--strict",
                named_args:      dependent.full_name,
-               ignore_failures: true
+               ignore_failures: !args.test_default_formula?
         end
 
         if testable_dependents.include? dependent
@@ -279,7 +279,7 @@ module Homebrew
           test "brew", "test", "--retry", "--verbose",
                named_args:      dependent.full_name,
                env:             env,
-               ignore_failures: !bottled_on_current_version
+               ignore_failures: !args.test_default_formula? && !bottled_on_current_version
           test_step = steps.last
         end
 

--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -146,7 +146,6 @@ module Homebrew
 
         if args.test_default_formula?
           # Build the default test formula.
-          @test_default_formula = true
           modified_formulae << "homebrew/test-bot/testbottest"
         end
 


### PR DESCRIPTION
Previously we were ignoring a bunch of failures in these cases which makes this CI check pretty useless (e.g. see https://github.com/Homebrew/brew/pull/16423).