### PR TITLE
cleanup_before: cleanup prefix on GitHub Actions (not self hosted).

### DIFF
--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -38,6 +38,8 @@ module Homebrew
 
             delete_or_move frameworks, sudo: true
           end
+
+          test "brew", "cleanup", "--prune-prefix"
         end
 
         # Keep all "brew" invocations after cleanup_shared


### PR DESCRIPTION
This ensures that there's no lingering bad symlinks (either already broken or broken by our previous cleanup steps) after the OS-wide cleanup happens.

This was necessary to add in https://github.com/Homebrew/brew/pull/16576 but there's enough other places this is needed and it didn't slow things down much so it's worth just doing by default.