### PR TITLE
formulae: specify that linter should only run on named formula

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -508,7 +508,7 @@ module Homebrew
 
         livecheck(formula) if !args.skip_livecheck? && !skip_online_checks
 
-        test "brew", "style", formula_name
+        test "brew", "style", "--formula", formula_name
         test "brew", "audit", *audit_args unless formula.deprecated?
         unless install_step_passed
           if ignore_failures


### PR DESCRIPTION
This reduces the scope of this audit to the expected use case. We are only trying to lint a single formula file here. This can become ambiguous since `brew style` doesn't know automatically if you are trying to lint a path, tap, cask or formula. We saw problems tangentially related to this in `homebrew/core` recently that were also based on changes to the cask loader which seem to have changed the default cask path in certain situations but this change allows us to work around those problems entirely.

Related to:
- https://github.com/Homebrew/brew/pull/16632#issuecomment-1937783354
- https://github.com/Homebrew/homebrew-core/pull/162341#issuecomment-1937866568
- https://github.com/Homebrew/homebrew-core/pull/162322