### PR TITLE
Fix RuboCop `Lint/RedundantDirGlobSort` and `Performance/MapCompact` offenses

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -228,12 +228,12 @@ module Homebrew
           git, "-C", repository,
           "diff-tree", "-r", "--name-only", "--diff-filter=#{filter}",
           start_revision, end_revision, "--", path
-        ).lines.map do |line|
+        ).lines.filter_map do |line|
           file = Pathname.new line.chomp
           next unless tap.formula_file?(file)
 
           tap.formula_file_to_name(file)
-        end.compact
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ PROJECT_ROOT = Pathname(__dir__).parent.freeze
 STUB_PATH = (PROJECT_ROOT/"spec/stub").freeze
 $LOAD_PATH.unshift(STUB_PATH)
 
-Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").sort.each do |file|
+Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").each do |file|
   require file
 end
 


### PR DESCRIPTION
- For https://github.com/Homebrew/brew/pull/16745.
