### PR TITLE
formulae: scope `brew audit`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -509,7 +509,7 @@ module Homebrew
         livecheck(formula) if !args.skip_livecheck? && !skip_online_checks
 
         test "brew", "style", "--formula", formula_name
-        test "brew", "audit", *audit_args unless formula.deprecated?
+        test "brew", "audit", "--formula", *audit_args unless formula.deprecated?
         unless install_step_passed
           if ignore_failures
             skipped formula_name, "install failed"


### PR DESCRIPTION
seeing audit failure in https://github.com/Homebrew/homebrew-core/actions/runs/8320806246/job/22766174322?pr=165919

```
Full audit yo --online --new output
  Error: No such file or directory @ rb_check_realpath_internal - /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/yo.rb
```

----

- similar to #1017
- relates to https://github.com/Homebrew/homebrew-core/pull/165919