### PR TITLE
test-bot: allow skipping repository audit

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -59,6 +59,8 @@ module Homebrew
              description: "Don't test livecheck."
       switch "--skip-recursive-dependents",
              description: "Only test the direct dependents."
+      switch "--skip-repository-audit",
+             description: "Don't audit the repository."
       switch "--skip-checksum-only-audit",
              description: "Don't audit checksum-only changes."
       switch "--skip-stable-version-audit",

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -427,10 +427,11 @@ module Homebrew
         audit_args = [formula_name]
         audit_args << "--online" unless skip_online_checks
         audit_args << "--except=unconfirmed_checksum_change" if args.skip_checksum_only_audit?
+        audit_args << "--except=github_repository,gitlab_repository,bitbucket_repository" if args.skip_repository_audit?
         audit_args << "--except=stable_version" if args.skip_stable_version_audit?
         audit_args << "--except=revision" if args.skip_revision_audit?
         if new_formula
-          audit_args << "--new" unless args.skip_repository_audit?
+          audit_args << "--new"
         else
           audit_args << "--git" << "--skip-style"
         end

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -428,8 +428,8 @@ module Homebrew
 
         audit_args = [formula_name]
         audit_args << "--online" unless skip_online_checks
-        audit_args << "--except=unconfirmed_checksum_change" if args.skip_checksum_only_audit?
         audit_args << "--except=#{repo_audits}" if args.skip_repository_audit?
+        audit_args << "--except=unconfirmed_checksum_change" if args.skip_checksum_only_audit?
         audit_args << "--except=stable_version" if args.skip_stable_version_audit?
         audit_args << "--except=revision" if args.skip_revision_audit?
         if new_formula

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -424,10 +424,12 @@ module Homebrew
         fetch_args << build_flag
         fetch_args << "--force" if args.cleanup?
 
+        repo_audits = "github_repository,gitlab_repository,bitbucket_repository"
+
         audit_args = [formula_name]
         audit_args << "--online" unless skip_online_checks
         audit_args << "--except=unconfirmed_checksum_change" if args.skip_checksum_only_audit?
-        audit_args << "--except=github_repository,gitlab_repository,bitbucket_repository" if args.skip_repository_audit?
+        audit_args << "--except=#{repo_audits}" if args.skip_repository_audit?
         audit_args << "--except=stable_version" if args.skip_stable_version_audit?
         audit_args << "--except=revision" if args.skip_revision_audit?
         if new_formula

--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -430,7 +430,7 @@ module Homebrew
         audit_args << "--except=stable_version" if args.skip_stable_version_audit?
         audit_args << "--except=revision" if args.skip_revision_audit?
         if new_formula
-          audit_args << "--new"
+          audit_args << "--new" unless args.skip_repository_audit?
         else
           audit_args << "--git" << "--skip-style"
         end


### PR DESCRIPTION
We often need to skip repository checks (repo age, notability, etc.) for various reasons. This PR allows us to skip those checks with a switch, so that we can reduce the number of ❌ PR's we are merging in homebrew-core.