### PR TITLE
test_formulae: preserve logs in `cleanup_during!`

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -339,8 +339,15 @@ module Homebrew
 
         test_header(:TestFormulae, method: :cleanup_during!)
 
+        # HOMEBREW_LOGS can be a subdirectory of HOMEBREW_CACHE.
+        # Preserve the logs in that case.
+        logs_are_in_cache = HOMEBREW_LOGS.ascend { |path| break true if path == HOMEBREW_CACHE }
+
+        test "mv", HOMEBREW_LOGS.to_s, (tmpdir = Dir.mktmpdir) if logs_are_in_cache
         FileUtils.chmod_R "u+rw", HOMEBREW_CACHE, force: true
         test "rm", "-rf", HOMEBREW_CACHE.to_s
+        FileUtils.mkdir_p HOMEBREW_LOGS.parent
+        test "mv", "#{tmpdir}/#{HOMEBREW_LOGS.basename}", HOMEBREW_LOGS.to_s if logs_are_in_cache
 
         if @cleaned_up_during.blank?
           @cleaned_up_during = true

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -346,8 +346,10 @@ module Homebrew
         test "mv", HOMEBREW_LOGS.to_s, (tmpdir = Dir.mktmpdir) if logs_are_in_cache
         FileUtils.chmod_R "u+rw", HOMEBREW_CACHE, force: true
         test "rm", "-rf", HOMEBREW_CACHE.to_s
-        FileUtils.mkdir_p HOMEBREW_LOGS.parent
-        test "mv", "#{tmpdir}/#{HOMEBREW_LOGS.basename}", HOMEBREW_LOGS.to_s if logs_are_in_cache
+        if logs_are_in_cache
+          FileUtils.mkdir_p HOMEBREW_LOGS.parent
+          test "mv", "#{tmpdir}/#{HOMEBREW_LOGS.basename}", HOMEBREW_LOGS.to_s
+        end
 
         if @cleaned_up_during.blank?
           @cleaned_up_during = true


### PR DESCRIPTION
On Linux by default, `HOMEBREW_LOGS` (`~/.cache/Homebrew/Logs`) is a subdirectory of `HOMEBREW_CACHE` (`~/.cache/Homebrew`). This means that `cleanup_during!` deletes the logs for the already-tested formulae, which is not ideal because these logs are to be uploaded as an artifact. These logs don't usually take up as much space as the cached downloads, and can be valuable for debugging, especially when a PR involves too many formulae that GitHub Actions cannot show all the logs.

Instead, we can move the logs to a temporary directory, and restore them after the cleanup.
