### PR TITLE
Add stable option to restrict tap syntax checks

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -71,6 +71,9 @@ module Homebrew
              description: "Only run the local system setup check step."
       switch "--only-tap-syntax",
              description: "Only run the tap syntax check step."
+      switch "--stable",
+             depends_on:  "--only-tap-syntax",
+             description: "Only run the tap syntax checks needed on stable brew."
       switch "--only-formulae",
              description: "Only run the formulae steps."
       switch "--only-formulae-detect",

--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -7,11 +7,13 @@ module Homebrew
         test_header(:TapSyntax)
         return unless tap.installed?
 
-        test "brew", "style", tap.name
+        test "brew", "style", tap.name unless args.stable?
 
         return if tap.formula_files.blank? && tap.cask_files.blank?
 
         test "brew", "readall", "--aliases", "--os=all", "--arch=all", tap.name
+        return if args.stable?
+
         test "brew", "audit", "--except=installed", "--tap=#{tap.name}"
       end
     end


### PR DESCRIPTION
Related to https://github.com/Homebrew/homebrew-core/pull/166913

Wasn't sure if we wanted a mutually exclusive arg (and optionally a separate Test) or just a dependent arg. Went with the simplest change which is `--stable` option.