### PR TITLE
tests: download only needed cached artifacts

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -21,7 +21,12 @@ module Homebrew
         verify_local_bottles
 
         with_env(HOMEBREW_DISABLE_LOAD_FORMULA: "1") do
-          download_artifacts_from_previous_run!("bottles{,_*}", dry_run: args.dry_run?)
+          bottle_specifier = if OS.linux?
+            "{linux,ubuntu}"
+          else
+            "#{MacOS.version}#{"-arm64" if Hardware::CPU.arm?}"
+          end
+          download_artifacts_from_previous_run!("bottles{,_#{bottle_specifier}*}", dry_run: args.dry_run?)
         end
         @bottle_checksums.merge!(
           bottle_glob("*", artifact_cache, ".{json,tar.gz}", bottle_tag: "*").to_h do |bottle_file|

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -16,7 +16,12 @@ module Homebrew
 
         install_formulae_if_needed_from_bottles!(args:)
 
-        download_artifacts_from_previous_run!("dependents{,_*}", dry_run: args.dry_run?)
+        artifact_specifier = if OS.linux?
+          "{linux,ubuntu}"
+        else
+          "#{MacOS.version}#{"-arm64" if Hardware::CPU.arm?}"
+        end
+        download_artifacts_from_previous_run!("dependents{,_#{artifact_specifier}*}", dry_run: args.dry_run?)
         @skip_candidates = if (tested_dependents_cache = artifact_cache/@tested_dependents_list).exist?
           tested_dependents_cache.read.split("\n")
         else


### PR DESCRIPTION
We don't need to download cached artifacts for other OSes/MacOS
versions, so let's skip doing that where we can.
