### PR TITLE
formulae: fix CLI arg name

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -434,7 +434,7 @@ module Homebrew
         if new_formula
           if !args.skip_new?
             audit_args << "--new"
-          elsif !args.skip_strict?
+          elsif !args.skip_new_strict?
             audit_args << "--strict"
           end
         else


### PR DESCRIPTION
Follow-up to #1041. Fixes:

    Error: CLI arg for `skip_strict?` is not declared for this command

Seen in Homebrew/homebrew-core#170246.