### PR TITLE
Fix deprecated `CoreTap.ensure_installed!`

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -48,7 +48,7 @@ module Homebrew
         elsif (canonical_formula_name = safe_formula_canonical_name(@argument, args:))
           unless canonical_formula_name.include?("/")
             ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
-            CoreTap.ensure_installed!
+            CoreTap.instance.ensure_installed!
           end
 
           @testing_formulae = [canonical_formula_name]


### PR DESCRIPTION
Should fix:
```console
Error: Calling `CoreTap.ensure_installed!` is deprecated! Use `CoreTap.instance.ensure_installed!` instead.
Please report this issue to the Homebrew/homebrew-test-bot tap, or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-test-bot/lib/tests/formulae_detect.rb:51
```