### PR TITLE
tests.yml: adjust `rm` command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
 
       - run: brew test-bot --only-cleanup-after
 
-      - run: rm -rvf *.bottle*.{json,tar.gz}
+      - run: rm -rvf -- *.bottle*.{json,tar.gz}
 
       - run: brew test-bot --only-setup --dry-run
 


### PR DESCRIPTION
If a bottle starts with a `-`, this could be interpreted as an option. Use `--` to mark end of options.