### PR TITLE
Update bottle cache specifiers

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -24,7 +24,7 @@ module Homebrew
           bottle_specifier = if OS.linux?
             "{linux,ubuntu}"
           else
-            "#{MacOS.version}#{"-arm64" if Hardware::CPU.arm?}"
+            "{macos-#{MacOS.version},#{MacOS.version}-#{Hardware::CPU.arch}}"
           end
           download_artifacts_from_previous_run!("bottles{,_#{bottle_specifier}*}", dry_run: args.dry_run?)
         end

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -19,7 +19,7 @@ module Homebrew
         artifact_specifier = if OS.linux?
           "{linux,ubuntu}"
         else
-          "#{MacOS.version}#{"-arm64" if Hardware::CPU.arm?}"
+          "{macos-#{MacOS.version},#{MacOS.version}-#{Hardware::CPU.arch}}"
         end
         download_artifacts_from_previous_run!("dependents{,_#{artifact_specifier}*}", dry_run: args.dry_run?)
         @skip_candidates = if (tested_dependents_cache = artifact_cache/@tested_dependents_list).exist?


### PR DESCRIPTION
1. Avoid downloading artifacts built for Apple Silicon on Intel
2. Make sure to download artifacts built on GitHub-hosted runners too
