### PR TITLE
bottles_fetch: skip disabled bottles

### DIFF
--- a/lib/tests/bottles_fetch.rb
+++ b/lib/tests/bottles_fetch.rb
@@ -22,6 +22,8 @@ module Homebrew
         test_header(:BottlesFetch, method: "fetch_bottles!(#{formula_name})")
 
         formula = Formula[formula_name]
+        return if formula.disabled?
+
         tags = formula.bottle_specification.collector.tags
 
         odie "#{formula_name} is missing bottles! Did you mean to use `brew pr-publish`?" if tags.blank?


### PR DESCRIPTION
We don't really care if bottles for disabled formulae will fail to
fetch.
