### PR TITLE
test_formulae: fix missing `workflowRun` attribute

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -54,6 +54,7 @@ module Homebrew
           next false if node.fetch("status") != "COMPLETED"
 
           workflow_run = node.fetch("workflowRun")
+          next false if workflow_run.blank?
           next false if workflow_run.fetch("event") != event_name
           next false if workflow_run.dig("workflow", "name") != workflow_name
 


### PR DESCRIPTION
Spotted at Homebrew/homebrew-core#173850.
