### PR TITLE
tests/setup: remove bootsnap install

### DIFF
--- a/lib/tests/setup.rb
+++ b/lib/tests/setup.rb
@@ -6,7 +6,7 @@ module Homebrew
       def run!(args:)
         test_header(:Setup)
 
-        test "brew", "install-bundler-gems", "--add-groups=ast,audit,bootsnap,bottle,formula_test,livecheck,style"
+        test "brew", "install-bundler-gems", "--add-groups=ast,audit,bottle,formula_test,livecheck,style"
 
         # Always output `brew config` output even when it doesn't fail.
         test "brew", "config", verbose: true


### PR DESCRIPTION
This is now bundled in Portable Ruby and we will remove it from other Rubies: https://github.com/Homebrew/brew/pull/17534