### PR TITLE
Debug typechecking not triggering in tap_syntax

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -10,6 +10,7 @@ module Homebrew
 
         # Run `brew typecheck` if this tap is typed.
         # TODO: consider in future if we want to allow unsupported taps here.
+        puts "tap.name: #{tap.name}, tap.path: #{tap.path}" if ENV["HOMEBREW_DEBUG"].present?
         if tap.official? && quiet_system(git, "-C", tap.path.to_s, "grep", "-qE", "^# typed: (true|strict|strong)$")
           test "brew", "typecheck", tap.name
         end


### PR DESCRIPTION
- For some reason this isn't triggering, see https://github.com/Homebrew/homebrew-command-not-found/actions/runs/10499444382/job/29086226541#step:4:14. Since the `grep` works fine for me locally, my hypothesis is something to do with the tap path on the CI runner.