### PR TITLE
Pass `git` into `tap_syntax` tests

### DIFF
--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -133,6 +133,7 @@ module Homebrew
       if no_only_args || args.only_tap_syntax?
         tests[:tap_syntax] = Tests::TapSyntax.new(tap:       tap || CoreTap.instance,
                                                   dry_run:   args.dry_run?,
+                                                  git:,
                                                   fail_fast: args.fail_fast?,
                                                   verbose:   args.verbose?)
       end

--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -10,7 +10,6 @@ module Homebrew
 
         # Run `brew typecheck` if this tap is typed.
         # TODO: consider in future if we want to allow unsupported taps here.
-        puts "tap.name: #{tap.name}, tap.path: #{tap.path}" if ENV["HOMEBREW_DEBUG"].present?
         if tap.official? && quiet_system(git, "-C", tap.path.to_s, "grep", "-qE", "^# typed: (true|strict|strong)$")
           test "brew", "typecheck", tap.name
         end


### PR DESCRIPTION
- So that `git -C /path/to/tap grep ...` works correctly to determine if a tap should be typechecked.
- Thanks for your patience with my various test PRs, here's it working: https://github.com/Homebrew/homebrew-command-not-found/actions/runs/10516250377/job/29138543034.