### PR TITLE
Skip `brew typecheck` if running on stable

### DIFF
--- a/lib/tests/tap_syntax.rb
+++ b/lib/tests/tap_syntax.rb
@@ -8,13 +8,15 @@ module Homebrew
         test_header(:TapSyntax)
         return unless tap.installed?
 
-        # Run `brew typecheck` if this tap is typed.
-        # TODO: consider in future if we want to allow unsupported taps here.
-        if tap.official? && quiet_system(git, "-C", tap.path.to_s, "grep", "-qE", "^# typed: (true|strict|strong)$")
-          test "brew", "typecheck", tap.name
-        end
+        unless args.stable?
+          # Run `brew typecheck` if this tap is typed.
+          # TODO: consider in future if we want to allow unsupported taps here.
+          if tap.official? && quiet_system(git, "-C", tap.path.to_s, "grep", "-qE", "^# typed: (true|strict|strong)$")
+            test "brew", "typecheck", tap.name
+          end
 
-        test "brew", "style", tap.name unless args.stable?
+          test "brew", "style", tap.name
+        end
 
         return if tap.formula_files.blank? && tap.cask_files.blank?
 


### PR DESCRIPTION
- Since `brew typecheck <tap>` is not in a `brew` release yet, we need to skip this for stable `tap_syntax` checks otherwise: https://github.com/Homebrew/homebrew-core/actions/runs/10516750573/job/29139564452?pr=182076