### PR TITLE
Update usage of `Tap#formula_file?`

### DIFF
--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -228,10 +228,10 @@ module Homebrew
           git, "-C", repository,
           "diff-tree", "-r", "--name-only", "--diff-filter=#{filter}",
           start_revision, end_revision, "--", path
-        ).lines.filter_map do |line|
-          file = Pathname.new line.chomp
+        ).lines(chomp: true).filter_map do |file|
           next unless tap.formula_file?(file)
 
+          file = Pathname.new(file)
           tap.formula_file_to_name(file)
         end
       end


### PR DESCRIPTION
Currently this method takes either a String or a Pathname which is fine since we were passing in a Pathname. I'm planning on changing that behavior in new PR so that it will only accept the String class going forward so I'm updating this to use the String class here. This should be completely backwards compatible.

- Relevant PR: https://github.com/Homebrew/brew/pull/18167

I'm not too familiar with this repo so I'm not entirely sure how to test this change.