### PR TITLE
Add `--tested-formulae` flag

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -104,6 +104,8 @@ module Homebrew
         comma_array "--skipped-or-failed-formulae=",
                     description: "Use these skipped or failed formulae from formulae steps for a " \
                                  "formulae dependents step."
+        comma_array "--tested-formulae=",
+                    description: "Use these tested formulae from formulae steps for a formulae dependents step."
         conflicts "--only-formulae-detect", "--testing-formulae"
         conflicts "--only-formulae-detect", "--added-formulae"
         conflicts "--only-formulae-detect", "--deleted-formulae"

--- a/lib/test_runner.rb
+++ b/lib/test_runner.rb
@@ -236,6 +236,7 @@ module Homebrew
         if (dependents_test = tests[:formulae_dependents])
           dependents_test.testing_formulae = testing_formulae
           dependents_test.skipped_or_failed_formulae = skipped_or_failed_formulae
+          dependents_test.tested_formulae = args.tested_formulae.to_a.presence || testing_formulae
 
           dependents_test.run!(args:)
         end


### PR DESCRIPTION
This is needed for Homebrew/homebrew-core#182696.

The problem that lead to the revert in Homebrew/homebrew-core#182754 is
due to `test-bot` not realising that there are dependents we had already
tested in the earlier formulae build job that do not need to be tested
anymore.

We can fix this by making sure `test-bot` knows all the formulae we had
previously tested passed via a `--tested-formulae` flag.

For clarity, let's rename the old `@tested_formulae` ivar to
`@testing_formulae_with_tested_dependents`.