### PR TITLE
formulae_dependents: fix fetching empty array of formulae

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -237,8 +237,10 @@ module Homebrew
             fetch_formulae << dependent.full_name
           end
 
-          test "brew", "fetch", "--retry", *fetch_formulae
-          return if steps.last.failed?
+          if fetch_formulae.present?
+            test "brew", "fetch", "--retry", *fetch_formulae
+            return if steps.last.failed?
+          end
 
           unlink_conflicts dependent
 


### PR DESCRIPTION
Fixes CI failures at Homebrew/homebrew-core#183951.

See https://github.com/Homebrew/homebrew-core/actions/runs/10761407159/job/29844078861?pr=183951#step:4:51
