### PR TITLE
formulae_dependents: skip recursive dependents on Linux

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -91,7 +91,10 @@ module Homebrew
         info_header "Determining dependents..."
 
         # Always skip recursive dependents on Intel. It's really slow.
-        skip_recursive_dependents = args.skip_recursive_dependents? || (OS.mac? && Hardware::CPU.intel?)
+        # Also skip recursive dependents on Linux unless it's a Linux-only formula.
+        skip_recursive_dependents = args.skip_recursive_dependents? ||
+                                    (OS.mac? && Hardware::CPU.intel?) ||
+                                    (OS.linux? && formula.requirements.exclude?(LinuxRequirement.new))
 
         uses_args = %w[--formula --eval-all]
         uses_include_test_args = [*uses_args, "--include-test"]


### PR DESCRIPTION
Except if we're testing a Linux-only formula.

This should help ease the load on our self-hosted Linux runner.
