### PR TITLE
test_formulae: strip `bottle_message`

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -244,7 +244,7 @@ module Homebrew
           else
             bottle_revision
           end
-          bottle_message = "Bottle for #{formula_name} built at #{bottle_commit_details}"
+          bottle_message = "Bottle for #{formula_name} built at #{bottle_commit_details}".strip
 
           if ENV["GITHUB_ACTIONS"].present?
             puts GitHub::Actions::Annotation.new(


### PR DESCRIPTION
`bottle_commit_details` can contain extraneous newlines, which makes the
log output a bit weird to parse. Let's fix that by calling `#strip`.
