### PR TITLE
formulae_dependents: ignore more failures from unbottled dependents

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -69,13 +69,17 @@ module Homebrew
         test "brew", "link", formula_name unless formula.keg_only?
 
         # Install formula dependencies. These may not be installed.
-        test "brew", "install", "--only-dependencies", formula_name,
-             env: { "HOMEBREW_DEVELOPER" => nil }
-        return if steps.last.failed?
+        test "brew", "install", "--only-dependencies",
+             named_args:      formula_name,
+             ignore_failures: !bottled?(formula, no_older_versions: true),
+             env:             { "HOMEBREW_DEVELOPER" => nil }
+        return unless steps.last.passed?
 
         # Restore etc/var files that may have been nuked in the build stage.
-        test "brew", "postinstall", formula_name
-        return if steps.last.failed?
+        test "brew", "postinstall",
+             named_args:      formula_name,
+             ignore_failures: !bottled?(formula, no_older_versions: true)
+        return unless steps.last.passed?
 
         source_dependents.each do |dependent|
           install_dependent(dependent, testable_dependents, build_from_source: true, args:)


### PR DESCRIPTION
Spotted at https://github.com/Homebrew/homebrew-core/actions/runs/10847530816/job/30117622523#step:3:8023.

A number of formulae fail at the `brew install --only-dependencies` step
because they have dependencies that are not yet bottled (and are
therefore themselves not bottled either).
