### PR TITLE
formulae_dependents: remove incompatible formulae from `@dependent_testing_formulae`

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -14,6 +14,8 @@ module Homebrew
         @tested_dependents_list = Pathname("tested-dependents-#{Utils::Bottles.tag}.txt")
 
         @dependent_testing_formulae = sorted_formulae - skipped_or_failed_formulae
+        unneeded_formulae = @tested_formulae - @testing_formulae
+        @dependent_testing_formulae -= unneeded_formulae
 
         install_formulae_if_needed_from_bottles!(args:)
 


### PR DESCRIPTION
This will allow us to skip attempting to test formulae that were never
built (because they're not compatible with the current runner).

Needed for Homebrew/homebrew-core#187308.
