### PR TITLE
formulae_dependents: don't clobber existing `skipped_or_failed_formulae`

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -8,8 +8,7 @@ module Homebrew
 
       def run!(args:)
         unneeded_formulae = @tested_formulae - @testing_formulae
-        skipped_or_failed_formulae ||= []
-        skipped_or_failed_formulae += unneeded_formulae
+        @skipped_or_failed_formulae += unneeded_formulae
 
         info_header "Skipped or failed formulae:"
         puts skipped_or_failed_formulae


### PR DESCRIPTION
Fixes
```
Error: Failed to find bottle for 'opencv'.
```
https://github.com/Homebrew/homebrew-core/actions/runs/10853013996/job/30140584720?pr=187308#step:3:62
