### PR TITLE
formulae_dependents: ignore even more failures from unbottled formulae

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -254,8 +254,10 @@ module Homebrew
 
           unlink_conflicts dependent
 
-          test "brew", "install", *build_args, "--only-dependencies", dependent.full_name,
-               env: { "HOMEBREW_DEVELOPER" => nil }
+          test "brew", "install", *build_args, "--only-dependencies",
+               named_args:      dependent.full_name,
+               ignore_failures: !bottled_on_current_version,
+               env:             { "HOMEBREW_DEVELOPER" => nil }
 
           env = {}
           env["HOMEBREW_GIT_PATH"] = nil if build_from_source && required_dependent_deps.any? do |d|


### PR DESCRIPTION
Fixes

      Error: /opt/homebrew/Cellar/opencv/4.10.0_6 is not a directory

https://github.com/Homebrew/homebrew-core/actions/runs/10853013996/job/30140781474#step:3:1535
