### PR TITLE
Include first error message in GitHub annotation

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -132,10 +132,17 @@ module Homebrew
       [@repository.glob("**/#{name}*").first, nil]
     end
 
-    def truncate_output(output, max_kb:, max_lines:)
-      max_length_start = [output.length - (max_kb * 1024), 0].max
+    def truncate_output(output, max_kb:, max_lines:, context_lines:)
+      output_lines = output.lines
+      first_error_index = output_lines.find_index { |line| line.match?(/\b[Ee]rror:\s+/) }
 
-      output[max_length_start..].lines.last(max_lines).join
+      if first_error_index.blank?
+        max_length_start = [output.length - (max_kb * 1024), 0].max
+        output[max_length_start..].lines.last(max_lines).join
+      else
+        start = [first_error_index - context_lines, 0].max
+        output_lines[start..(start + max_lines - 1)].join[..(max_kb * 1024)]
+      end
     end
 
     def run(dry_run: false, fail_fast: false)
@@ -213,7 +220,7 @@ module Homebrew
 
         # GitHub Actions has a 64KB maximum for annotiations. That's a bit
         # too long so instead let's go for a maximum of 24KB or 256 lines.
-        annotation_output = truncate_output(@output, max_kb: 24, max_lines: 256)
+        annotation_output = truncate_output(@output, max_kb: 24, max_lines: 256, context_lines: 10)
 
         annotation_title = "`#{command_trimmed}` failed on #{os_string}!"
         file = path.to_s.delete_prefix("#{@repository}/")


### PR DESCRIPTION
The first error message is often found before the last 256 lines, so
isn't included in the annotation.

Let's adjust `#truncate_output` so it includes this error message if
found instead. Searching for error messages is a little naive, but it
matches the way `clang`, `gcc`, and `rustc` print error messages. We can
make this more sophisticated later if desired.