### PR TITLE
Set `HOMEBREW_VERIFY_ATTESTATIONS`

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -72,8 +72,7 @@ module Homebrew
       ENV["HOMEBREW_NO_ENV_HINTS"] = "1"
       ENV["HOMEBREW_PATH"] = ENV["PATH"] =
         "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:#{ENV.fetch("PATH")}"
-      # https://github.com/Homebrew/brew/issues/14274
-      ENV["PYTHONDONTWRITEBYTECODE"] = "1"
+      ENV["HOMEBREW_VERIFY_ATTESTATIONS"] = "1"
 
       if local?(args)
         home = "#{Dir.pwd}/home"


### PR DESCRIPTION
We still have a few bottles with missing attestations, but our CI
doesn't catch it because dependents are installed with
`HOMEBREW_DEVELOPER` unset.

Let's find out what those bottles are by ensuring we verify attestations
when installing bottles.

Also, remove `PYTHONDONTWRITEBYTECODE` because setting it here doesn't
do anything.