### PR TITLE
formulae_dependents: ignore more unbottled errors

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -267,7 +267,7 @@ module Homebrew
           test "brew", "install", *build_args,
                named_args:      dependent.full_name,
                env:             env.merge({ "HOMEBREW_DEVELOPER" => nil }),
-               ignore_failures: !args.test_default_formula? && build_from_source && !bottled_on_current_version
+               ignore_failures: !args.test_default_formula? && !bottled_on_current_version
           install_step = steps.last
 
           return unless install_step.passed?


### PR DESCRIPTION
We shouldn't fail CI if we fail to install an unbottled dependent, even
when we're not building from source.

Fixes failures seen at https://github.com/Homebrew/homebrew-core/actions/runs/10956242397/job/30553837181?pr=189352
