### PR TITLE
formulae_dependents: improve `texlive` handling

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -85,6 +85,17 @@ module Homebrew
              ignore_failures: !bottled?(formula, no_older_versions: true)
         return unless steps.last.passed?
 
+        # Test texlive first to avoid GitHub-hosted runners running out of storage.
+        # TODO: Try generalising this by sorting dependents according to install size,
+        #       where ideally install size should include recursive dependencies.
+        [source_dependents, bottled_dependents].each do |dependent_array|
+          texlive = dependent_array.find { |dependent| dependent.name == "texlive" }
+          next unless texlive.present?
+
+          dependent_array.delete(texlive)
+          dependent_array.unshift(texlive)
+        end
+
         source_dependents.each do |dependent|
           install_dependent(dependent, testable_dependents, build_from_source: true, args:)
           install_dependent(dependent, testable_dependents, args:) if bottled?(dependent)


### PR DESCRIPTION
The `texlive` bottle is gigantic and has about a thousand dependencies.
This tends to make GitHub-hosted runners run out of storage by the time
they get around to testing it, particularly since it comes late in the
alphabet (and we test dependents in alphabetical order).

To try to minimise usage of our self-hosted runner, let's test `texlive`
as early as possible to increase the chances of the runner having
sufficient storage to be able to test `texlive`.
