### PR TITLE
Verify attesations only during formula build step

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -86,8 +86,10 @@ module Homebrew
 
       tap = resolve_test_tap(args.tap)
 
-      ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1" if tap.to_s == CoreTap.instance.name
-      ENV["HOMEBREW_VERIFY_ATTESTATIONS"] = "1" if tap.to_s == CoreTap.instance.name
+      if tap.to_s == CoreTap.instance.name
+        ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+        ENV["HOMEBREW_VERIFY_ATTESTATIONS"] = "1" if args.only_formulae?
+      end
 
       # Tap repository if required, this is done before everything else
       # because Formula parsing and/or git commit hash lookup depends on it.


### PR DESCRIPTION
We're regularly hitting rate limits in Homebrew/core after we started
verifying all these attestations, so let's try to limit doing it for
now.
