### PR TITLE
tests/formulae: skip attestation verification when building `gh`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -474,9 +474,16 @@ module Homebrew
         install_args = ["--verbose", "--formula"]
         install_args << build_flag
 
+        # We can't verify attestations if we're building `gh`.
+        verify_attestations = if formula_name == "gh"
+          nil
+        else
+          ENV.fetch("HOMEBREW_VERIFY_ATTESTATIONS", nil)
+        end
         # Don't care about e.g. bottle failures for dependencies.
         test "brew", "install", "--only-dependencies", *install_args, formula_name,
-             env: { "HOMEBREW_DEVELOPER" => nil }
+             env: { "HOMEBREW_DEVELOPER"           => nil,
+                    "HOMEBREW_VERIFY_ATTESTATIONS" => verify_attestations }
 
         # Do this after installing dependencies to avoid skipping formulae
         # that build with and declare a dependency on GCC. See discussion at


### PR DESCRIPTION
Fixes

    Error: A `brew install --formula gh` process has already locked /opt/homebrew/Cellar/gh.
    Please wait for it to finish or terminate it to continue.

Homebrew/homebrew-core#192550
https://github.com/Homebrew/homebrew-core/actions/runs/11133201051/job/30938871245?pr=192550#step:3:53
