### PR TITLE
tests/formulae: skip attestation verification when building `gh` (again)

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -510,7 +510,8 @@ module Homebrew
         install_step_passed ||= begin
           test("brew", "install", *install_args,
                named_args:      formula_name,
-               env:             env.merge({ "HOMEBREW_DEVELOPER" => nil }),
+               env:             env.merge({ "HOMEBREW_DEVELOPER"           => nil,
+                                            "HOMEBREW_VERIFY_ATTESTATIONS" => verify_attestations }),
                ignore_failures:, report_analytics: true)
           steps.last.passed?
         end


### PR DESCRIPTION
Unfortunately #1247 was not sufficient.

https://github.com/Homebrew/homebrew-core/actions/runs/11133201051/job/30950399155?pr=192550#step:3:60
