### PR TITLE
tests/formulae: skip attestation verification when bottle-reinstalling `gh`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -297,8 +297,15 @@ module Homebrew
           @unchanged_dependencies -= @unchanged_build_dependencies
         end
 
-        test "brew", "install", "--only-dependencies", @bottle_filename
-        test "brew", "install", @bottle_filename
+        verify_attestations = if formula.name == "gh"
+          nil
+        else
+          ENV.fetch("HOMEBREW_VERIFY_ATTESTATIONS", nil)
+        end
+        test "brew", "install", "--only-dependencies", @bottle_filename,
+             env: { "HOMEBREW_VERIFY_ATTESTATIONS" => verify_attestations }
+        test "brew", "install", @bottle_filename,
+             env: { "HOMEBREW_VERIFY_ATTESTATIONS" => verify_attestations }
       end
 
       def build_bottle?(formula, args:)


### PR DESCRIPTION
This should hopefully be the last of these?

https://github.com/Homebrew/homebrew-core/actions/runs/11133201051/job/30951261825?pr=192550#step:3:44

Follow-up to #1247 and #1248.
