### PR TITLE
cleanup_before: untap unneeded taps on GitHub-hosted runners

### DIFF
--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -13,7 +13,8 @@ module Homebrew
 
         Pathname.glob("*.bottle*.*").each(&:unlink)
 
-        on_github_hosted_runner = ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
+        on_github_hosted_runner = ENV["HOMEBREW_GITHUB_ACTIONS"].present? &&
+                                  ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].blank?
         if on_github_hosted_runner
           # minimally fix brew doctor failures (a full clean takes ~5m)
           if OS.linux?

--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -13,7 +13,8 @@ module Homebrew
 
         Pathname.glob("*.bottle*.*").each(&:unlink)
 
-        if ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
+        on_github_hosted_runner = ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
+        if on_github_hosted_runner
           # minimally fix brew doctor failures (a full clean takes ~5m)
           if OS.linux?
             # brew doctor complains
@@ -48,6 +49,11 @@ module Homebrew
         cleanup_shared
 
         installed_taps = Tap.select(&:installed?).map(&:name)
+        if on_github_hosted_runner && tap.to_s == CoreTap.instance.name
+          (installed_taps - REQUIRED_TAPS).each do |tap|
+            test "brew", "untap", tap
+          end
+        end
         (REQUIRED_TAPS - installed_taps).each do |tap|
           test "brew", "tap", tap
         end


### PR DESCRIPTION
Should help us get rid of the strange warnings seen in [^1]. `aws/tap/aws-sam-cli` calls `opoo` unconditionally once evaluated [^2]. The tap `aws/tap` is installed on GitHub-hosted runners, and we evaluate all formulae when determining the dependents of testing formulae.

A more ideal and comprehensive solution would be to untap all unneeded taps by (recursively) determining which taps are actually needed by the formulae in the testing tap, but that requires evaluating all formulae in the testing tap and can be a bit more work. And in the end, for third-party taps, doing that will still not eliminate the warnings if a dependency has an unconditional `opoo` call like that. So for now, I'm restricting the cleanup to `homebrew/core`.

[^1]: https://github.com/Homebrew/homebrew-core/actions/runs/11148695947/job/30986582554?pr=192640
[^2]: https://github.com/aws/homebrew-tap/blob/f2dcc08fa89256b3893a6cfc82e3ac71b05ce28e/Formula/_aws-sam-cli.rb#L58
