### PR TITLE
Revert "cleanup_before: untap unneeded taps on GitHub-hosted runners"

### DIFF
--- a/lib/tests/cleanup_before.rb
+++ b/lib/tests/cleanup_before.rb
@@ -13,9 +13,7 @@ module Homebrew
 
         Pathname.glob("*.bottle*.*").each(&:unlink)
 
-        on_github_hosted_runner = ENV["HOMEBREW_GITHUB_ACTIONS"].present? &&
-                                  ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].blank?
-        if on_github_hosted_runner
+        if ENV["HOMEBREW_GITHUB_ACTIONS"] && !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
           # minimally fix brew doctor failures (a full clean takes ~5m)
           if OS.linux?
             # brew doctor complains
@@ -50,11 +48,6 @@ module Homebrew
         cleanup_shared
 
         installed_taps = Tap.select(&:installed?).map(&:name)
-        if on_github_hosted_runner && tap.to_s == CoreTap.instance.name
-          (installed_taps - REQUIRED_TAPS).each do |tap|
-            test "brew", "untap", tap
-          end
-        end
         (REQUIRED_TAPS - installed_taps).each do |tap|
           test "brew", "tap", tap
         end


### PR DESCRIPTION
Reverts Homebrew/homebrew-test-bot#1250