### PR TITLE
test_cleanup: fix moving of same-named files

### DIFF
--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -47,10 +47,14 @@ module Homebrew
         else
           FileUtils.rm_rf paths
         end
-      elsif sudo
-        test "sudo", "mv", *paths, Dir.mktmpdir
       else
-        FileUtils.mv paths, Dir.mktmpdir, force: true
+        paths.each do |path|
+          if sudo
+            test "sudo", "mv", path, Dir.mktmpdir
+          else
+            FileUtils.mv path, Dir.mktmpdir, force: true
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Take 2 at #1250; fixes https://github.com/Homebrew/homebrew-test-bot/pull/1250#issuecomment-2389466333.

The existing logic for moving files can silently fail when some files to move have a same name. This can be revealed as follows:

```console
$ mv -fv /opt/homebrew/Library/Taps/hashicorp/homebrew-tap /opt/homebrew/Library/Taps/azure/homebrew-bicep /opt/homebrew/Library/Taps/aws/homebrew-tap /private/tmp/d20241005-13189-6pyqe7
/opt/homebrew/Library/Taps/hashicorp/homebrew-tap -> /private/tmp/d20241005-13189-6pyqe7/homebrew-tap
/opt/homebrew/Library/Taps/azure/homebrew-bicep -> /private/tmp/d20241005-13189-6pyqe7/homebrew-bicep
mv: rename /opt/homebrew/Library/Taps/aws/homebrew-tap to /private/tmp/d20241005-13189-6pyqe7/homebrew-tap: Directory not empty
```

Fix that by creating a temporary directory for each file to move.
