### PR TITLE
test_formulae: relax bottle requirement for test deps of `:all` bottles

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -271,7 +271,9 @@ module Homebrew
         # up the dep tree when we encounter an `:all` bottle because
         # a formula is not bottled unless its dependencies are.
         if formula.bottle_specification.tag?(Utils::Bottles.tag(:all))
-          formula.deps.all? { |dep| bottled?(dep.to_formula, no_older_versions:) }
+          formula.deps.all? do |dep|
+            bottled?(dep.to_formula, no_older_versions: no_older_versions && (!dep.test? || dep.build?))
+          end
         else
           formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions:)
         end

--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -272,7 +272,8 @@ module Homebrew
         # a formula is not bottled unless its dependencies are.
         if formula.bottle_specification.tag?(Utils::Bottles.tag(:all))
           formula.deps.all? do |dep|
-            bottled?(dep.to_formula, no_older_versions: no_older_versions && (!dep.test? || dep.build?))
+            bottle_no_older_versions = no_older_versions && (!dep.test? || dep.build?)
+            bottled?(dep.to_formula, no_older_versions: bottle_no_older_versions)
           end
         else
           formula.bottle_specification.tag?(Utils::Bottles.tag, no_older_versions:)


### PR DESCRIPTION
`test-bot` is erroneously skipping builds for dependents of formulae
with `:all` bottles when the formula with an `:all` bottle has a test
dependency that isn't bottled.

See, for example:

https://github.com/Homebrew/homebrew-core/actions/runs/11278840144/job/31382054266#step:3:33

In the above example, `sfcgal` depends on `cgal`, and `cgal` has an
`:all` bottle and a `:test` dependency on `qt`, which is not yet bottled
on Sequoia. We should be ok with building a bottle for `sfcgal` in this
case.
