### PR TITLE
test_formulae: avoid trying to install unavailable bottle

### DIFF
--- a/lib/test_formulae.rb
+++ b/lib/test_formulae.rb
@@ -280,6 +280,8 @@ module Homebrew
         # a formula is not bottled unless its dependencies are.
         if formula.bottle_specification.tag?(Utils::Bottles.tag(:all))
           formula.deps.all? do |dep|
+            next false if @skipped_or_failed_formulae.include?(dep.name)
+
             bottle_no_older_versions = no_older_versions && (!dep.test? || dep.build?)
             bottled?(dep.to_formula, no_older_versions: bottle_no_older_versions)
           end


### PR DESCRIPTION
Issue was seen in https://github.com/Homebrew/homebrew-core/pull/193114 where `cgal` cannot fetch a `qt` bottle as it wasn't built on Sequoia and test runner does not download Sonoma bottles.

Not sure yet if this does what I want.
