### PR TITLE
tests/formulae: add now-mandatory `--ignore-dependencies` option

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -610,7 +610,7 @@ module Homebrew
         cleanup_bottle_etc_var(formula) if cleanup?(args)
 
         if @unchanged_dependencies.present?
-          test "brew", "uninstall", "--formulae", "--force", *@unchanged_dependencies
+          test "brew", "uninstall", "--formulae", "--force", "--ignore-dependencies", *@unchanged_dependencies
         end
       end
 


### PR DESCRIPTION
Since Homebrew/brew#18784 `brew uninstall` requires the `--ignore-dependencies` option to be used explicitly.

Fixes failure seen at https://github.com/Homebrew/homebrew-core/actions/runs/11889490048/job/33126293058?pr=198065.
