### PR TITLE
tests/formulae: add missing `--ignore-dependencies` option

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -293,7 +293,7 @@ module Homebrew
         @testing_formulae.delete(formula.name)
 
         unless @unchanged_build_dependencies.empty?
-          test "brew", "uninstall", "--formulae", "--force", *@unchanged_build_dependencies
+          test "brew", "uninstall", "--formulae", "--force", "--ignore-dependencies", *@unchanged_build_dependencies
           @unchanged_dependencies -= @unchanged_build_dependencies
         end
 


### PR DESCRIPTION
One more fix like https://github.com/Homebrew/homebrew-test-bot/pull/1305.

Fixes failure seen at https://github.com/Homebrew/homebrew-core/actions/runs/11889979173/job/33128643880?pr=198048.
