### PR TITLE
tests/formulae_dependents: another `--ignore-dependencies` fix

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -326,7 +326,7 @@ module Homebrew
           test_step = steps.last
         end
 
-        test "brew", "uninstall", "--force", dependent.full_name
+        test "brew", "uninstall", "--force", "--ignore-dependencies", dependent.full_name
 
         all_tests_passed = (dependent_was_previously_installed || install_step.passed?) &&
                            linkage_step.passed? &&


### PR DESCRIPTION
One more (and hopefully last) fix like #1305 and #1306. When we test dependents of multiple formulae, a dependent of one formula being tested can happen to be a dependency of another formula being tested. In this case, we need the `--ignore-dependencies` option to force removal of the dependent/dependency formula. When testing the dependents of the removed formula, `brew install --only-dependencies` ensures that it is reinstalled.

Fixes failure seen at https://github.com/Homebrew/homebrew-core/actions/runs/11923246241/job/33242018653?pr=198240.
