### PR TITLE
Update `#livecheckable?` usage

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -323,7 +323,7 @@ module Homebrew
       end
 
       def livecheck(formula)
-        return unless formula.livecheckable?
+        return unless formula.livecheck_defined?
         return if formula.livecheck.skip?
 
         livecheck_step = test "brew", "livecheck", "--formula", "--json", "--full-name", formula.full_name


### PR DESCRIPTION
The `#livecheckable?` method for formulae/casks/resources is being renamed to `#livecheck_defined?` (https://github.com/Homebrew/brew/pull/18839). This updates related method calls, so we can deprecate `#livecheckable?`.

I've set this as a draft until the related brew PR is merged. The `odeprecated` calls for `#livecheckable?` are currently commented out and I will enable them in a follow-up PR (after this is merged).