### PR TITLE
workflows/tests: fix template-injection zizmor findings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,14 +75,18 @@ jobs:
             --junit \
             --only-json-tab \
             --skip-dependents \
-            --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
+            --testing-formulae="$TESTING_FORMULAE"
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.testing_formulae }}
 
       - run: |
           brew test-bot --only-formulae-dependents --junit \
-                        --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }} \
-                        --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+                        --testing-formulae="$TESTING_FORMULAE" \
+                        --skipped-or-failed-formulae="$SKIPPED_OR_FAILED_FORMULAE"
+        env:
+          TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.testing_formulae }}
+          SKIPPED_OR_FAILED_FORMULAE: ${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
 
       - name: Output brew test-bot failures
         run: |


### PR DESCRIPTION
Avoid template injection by using environment variables to represent template values.
