### PR TITLE
formulae: use livecheck --autobump option

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -326,7 +326,8 @@ module Homebrew
         return unless formula.livecheck_defined?
         return if formula.livecheck.skip?
 
-        livecheck_step = test "brew", "livecheck", "--formula", "--json", "--full-name", formula.full_name
+        livecheck_step = test "brew", "livecheck", "--autobump", "--formula",
+                              "--json", "--full-name", formula.full_name
 
         return if livecheck_step.failed?
         return unless livecheck_step.output?


### PR DESCRIPTION
We recently modified the behavior of `brew livecheck` to skip packages in the tap's autobump list, so this change is causing autobumped formulae to fail the `brew livecheck` part of CI testing. This adds the `--autobump` option to the `brew livecheck` call, which will ensure that livecheck doesn't skip autobumped formulae.