### PR TITLE
tests/formulae{,_dependents}: add special handling for `bash`

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -52,6 +52,11 @@ module Homebrew
 
         return unless ENV["GITHUB_ACTIONS"]
 
+        # Remove `bash` after it is tested, since leaving a broken `bash`
+        # installation in the environment can cause issues with subsequent
+        # GitHub Actions steps.
+        test "brew", "uninstall", "--formula", "--force", "bash" if @testing_formulae.include?("bash")
+
         File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
           f.puts "skipped_or_failed_formulae=#{@skipped_or_failed_formulae.join(",")}"
         end

--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -37,6 +37,15 @@ module Homebrew
           dependent_formulae!(formula_name, args:)
           puts
         end
+
+        return unless ENV["GITHUB_ACTIONS"]
+
+        # Remove `bash` after it is tested, since leaving a broken `bash`
+        # installation in the environment can cause issues with subsequent
+        # GitHub Actions steps.
+        return unless @dependent_testing_formulae.include?("bash")
+
+        test "brew", "uninstall", "--formula", "--force", "bash"
       end
 
       private


### PR DESCRIPTION
Should unblock Homebrew/homebrew-core#206855.
