### PR TITLE
Add HOMEBREW_TEST_BOT environment variable

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -120,6 +120,7 @@ module Homebrew
           ENV["HOMEBREW_COLOR"] = "1"
           ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"
         end
+        ENV["HOMEBREW_TEST_BOT"] = "1"
 
         Homebrew::TestBot.run!(args)
       end


### PR DESCRIPTION
This can be used in Homebrew/brew to detect if we're running inside of `brew test-bot`.

See https://github.com/Homebrew/brew/pull/19326#issuecomment-2667494086 for an example usage.