### PR TITLE
packages_detect: fix typechecking error

### DIFF
--- a/lib/tests/packages_detect.rb
+++ b/lib/tests/packages_detect.rb
@@ -230,9 +230,9 @@ module Homebrew
           start_revision, end_revision, "--", path
         ).lines(chomp: true).filter_map do |file|
           if tap.formula_file?(file)
-            tap.formula_file_to_name(file)
+            tap.formula_file_to_name(Pathname.new(file))
           elsif tap.cask_file?(file)
-            file.basename(".rb").to_s
+            File.basename(file, ".rb")
           end
         end.compact
       end


### PR DESCRIPTION
Fixes

    Error: Parameter 'file': Expected type Pathname, got type String with value "Formula/s/systemd.rb"

https://github.com/Homebrew/homebrew-core/actions/runs/13921083284/job/38954279815#step:4:29
