### PR TITLE
tests/formulae: add another `--ignore-dependencies` flag

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -294,7 +294,7 @@ module Homebrew
         bottle_merge_args << "--keep-old" if args.keep_old? && !new_formula
 
         test "brew", "bottle", *bottle_merge_args
-        test "brew", "uninstall", "--formula", "--force", formula.full_name
+        test "brew", "uninstall", "--formula", "--force", "--ignore-dependencies", formula.full_name
 
         @testing_formulae.delete(formula.name)
 


### PR DESCRIPTION
This is essentially the same change as #1305, #1306, and #1307.

Fixes https://github.com/Homebrew/homebrew-core/actions/runs/13925253960/job/38968023209#step:5:64
