### PR TITLE
ENV: define `HOMEBREW_ARM64_TESTING` variable on ARM Linux runners

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -62,6 +62,7 @@ module Homebrew
 
       ENV["HOMEBREW_BOOTSNAP"] = "1" if OS.linux? || (OS.mac? && MacOS.version != :sequoia)
       ENV["HOMEBREW_DEVELOPER"] = "1"
+      ENV["HOMEBREW_ARM64_TESTING"] = "1" if OS.linux? && Hardware::CPU.arm?
       ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
       ENV["HOMEBREW_NO_EMOJI"] = "1"
       ENV["HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK"] = "1"


### PR DESCRIPTION
Fixes CI errors, e.g.: https://github.com/Homebrew/homebrew-core/actions/runs/13992089255/job/39178306786#step:3:218