### PR TITLE
Use `main` as the default branch.

### DIFF
--- a/.github/workflows/sync-default-branches.yml
+++ b/.github/workflows/sync-default-branches.yml
@@ -45,19 +45,20 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: true
 
-      - name: Setup target branch
+      - name: Get target SHA
+        id: sha
         run: |
-          git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
-          git reset --hard "origin/${SOURCE_BRANCH}"
+          TARGET_SHA=$(git ls-remote origin "refs/heads/${SOURCE_BRANCH}" | cut -f1)
+          echo "target=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
         env:
           SOURCE_BRANCH: ${{ steps.branches.outputs.source }}
-          TARGET_BRANCH: ${{ steps.branches.outputs.target }}
 
       - name: Push target branch
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-        run: git push origin "${TARGET_BRANCH}" --force-with-lease
+        run: git push origin "${TARGET_SHA}:refs/heads/${TARGET_BRANCH}" --force
         env:
+          TARGET_SHA: ${{ steps.sha.outputs.target }}
           TARGET_BRANCH: ${{ steps.branches.outputs.target }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
   push:
-    branches: master
+    branches:
+      - main
+      - master
   pull_request:
 jobs:
   rspec:
@@ -38,7 +40,7 @@ jobs:
           - os: Linux
             runner: ubuntu-latest
             workdir: /github/home
-            container: '{"image": "ghcr.io/homebrew/ubuntu22.04:master", "options": "--user=linuxbrew"}'
+            container: '{"image": "ghcr.io/homebrew/ubuntu22.04:main", "options": "--user=linuxbrew"}'
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container && fromJSON(matrix.container) || '' }}

--- a/lib/test_cleanup.rb
+++ b/lib/test_cleanup.rb
@@ -139,7 +139,7 @@ module Homebrew
       default_branch = Utils.popen_read(
         git, "-C", repository, "symbolic-ref", "refs/remotes/origin/HEAD", "--short"
       ).strip.presence
-      default_branch ||= "origin/master"
+      default_branch ||= "origin/main"
       default_branch
     end
 

--- a/lib/tests/formulae_detect.rb
+++ b/lib/tests/formulae_detect.rb
@@ -34,7 +34,7 @@ module Homebrew
         test_header(:FormulaeDetect, method: :detect_formulae!)
 
         url = nil
-        origin_ref = "origin/master"
+        origin_ref = "origin/main"
 
         github_repository = ENV.fetch("GITHUB_REPOSITORY", nil)
         github_ref = ENV.fetch("GITHUB_REF", nil)


### PR DESCRIPTION
Port various changes from other repositories and make fixes to support the default `main` branch for both homebrew-test-bot and other taps by default.