### PR TITLE
test_bot: set `HOMEBREW_DOWNLOAD_CONCURRENCY` in Homebrew/core

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -86,9 +86,10 @@ module Homebrew
 
       tap = resolve_test_tap(args.tap)
 
-      if tap.to_s == CoreTap.instance.name
+      if tap.core_tap?
         ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
         ENV["HOMEBREW_VERIFY_ATTESTATIONS"] = "1" if args.only_formulae?
+        ENV["HOMEBREW_DOWNLOAD_CONCURRENCY"] = "8"
       end
 
       # Tap repository if required, this is done before everything else


### PR DESCRIPTION
Let's see if we can kick the tires on this by seeing how it works in CI.

Also, simplify the check for whether we are testing Homebrew/core.
