### PR TITLE
test_bot: set download concurrency to auto.

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -89,7 +89,7 @@ module Homebrew
       if tap&.core_tap?
         ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
         ENV["HOMEBREW_VERIFY_ATTESTATIONS"] = "1" if args.only_formulae?
-        ENV["HOMEBREW_DOWNLOAD_CONCURRENCY"] = "8"
+        ENV["HOMEBREW_DOWNLOAD_CONCURRENCY"] = "auto"
       end
 
       # Tap repository if required, this is done before everything else


### PR DESCRIPTION
This is a nicer default that will adjust appropriately for the number of cores in a given runner.