### PR TITLE
cmd/test-bot: add `--concurrent-downloads` flag

### DIFF
--- a/cmd/test-bot.rb
+++ b/cmd/test-bot.rb
@@ -20,6 +20,8 @@ module Homebrew
                description: "Print what would be done rather than doing it."
         switch "--cleanup",
                description: "Clean all state from the Homebrew directory. Use with care!"
+        switch "--concurrent-downloads",
+               description: "Invoke `brew` with `HOMEBREW_DOWNLOAD_CONCURRENCY=auto`."
         switch "--skip-setup",
                description: "Don't check if the local system is set up correctly."
         switch "--build-from-source",

--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -60,6 +60,7 @@ module Homebrew
         raise UsageError, "cannot use --cleanup from HOMEBREW_PREFIX as it will delete all output."
       end
 
+      ENV["HOMEBREW_DOWNLOAD_CONCURRENCY"] = "auto" if args.concurrent_downloads?
       ENV["HOMEBREW_BOOTSNAP"] = "1" if OS.linux? || (OS.mac? && MacOS.version != :sequoia)
       ENV["HOMEBREW_DEVELOPER"] = "1"
       ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
@@ -89,7 +90,6 @@ module Homebrew
       if tap&.core_tap?
         ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
         ENV["HOMEBREW_VERIFY_ATTESTATIONS"] = "1" if args.only_formulae?
-        ENV["HOMEBREW_DOWNLOAD_CONCURRENCY"] = "auto"
       end
 
       # Tap repository if required, this is done before everything else


### PR DESCRIPTION
The idea here is to pass `--concurrent-downloads` to `brew test-bot`
invocations unless a label is applied, which would help unblock
Homebrew/homebrew-core#231723.

It would also allow external tap authors to test it in their own taps if
desired.

Compantion to Homebrew/homebrew-core#231897
