### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete regular expression for hostnames

### DIFF
--- a/lib/test_bot.rb
+++ b/lib/test_bot.rb
@@ -38,7 +38,7 @@ module Homebrew
       git_url = ENV.fetch("GITHUB_REPOSITORY", nil)
       return if git_url.blank?
 
-      url_path = git_url.sub(%r{^https?://.*github\.com/}, "")
+      url_path = git_url.sub(%r{^https?://github\.com/}, "")
                         .chomp("/")
                         .sub(/\.git$/, "")
 


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-test-bot/security/code-scanning/13](https://github.com/Homebrew/homebrew-test-bot/security/code-scanning/13)

To fix the problem, the regular expression should be updated to ensure that `github.com/` is matched only in the hostname portion of the URL, immediately following the protocol. This can be done by replacing `.*github\.com/` with `github\.com/` directly after the protocol, i.e., `^https?://github\.com/`. This change ensures that only URLs starting with `http://github.com/` or `https://github.com/` are matched, and avoids matching `github.com/` elsewhere in the URL. The change should be made in the `sub` call on line 41 of `lib/test_bot.rb`.

No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
