### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
       - master
-  pull_request:
+pull_request:
+permissions: {}
 jobs:
   rspec:
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
 jobs:
   rspec:
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - master
-pull_request:
+  pull_request:
 permissions: {}
 jobs:
   rspec:


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-test-bot/security/code-scanning/9](https://github.com/Homebrew/homebrew-test-bot/security/code-scanning/9)

To fix the problem, you should add a `permissions` block to the `rspec` job, specifying the minimal permissions required for the job to run successfully. If the job only needs to read repository contents (which is typical for CI jobs running tests), set `contents: read`. If it needs additional permissions (e.g., to create issues or update pull requests), add those as needed. The change should be made in the `.github/workflows/tests.yml` file, specifically by adding the `permissions` block under the `rspec` job, at the same level as `strategy`, `name`, and `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
