### PR TITLE
lib/step: improve error matcher for error output

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -135,7 +135,8 @@ module Homebrew
     def truncate_output(output, max_kb:, context_lines:)
       output_lines = output.lines
       first_error_index = output_lines.find_index do |line|
-        line.match?(/\berror:\s+/i) && !line.strip.match?(/^::error( .*)?::/)
+        !line.strip.match?(/^::error( .*)?::/) &&
+          (line.match?(/\berror:\s+/i) || line.match?(/\bcmake error\b/i))
       end
 
       if first_error_index.blank?


### PR DESCRIPTION
CMake errors do not currently match our existing regex, so let's adjust
this to match these errors specifically.

See, for example, https://github.com/Homebrew/homebrew-core/actions/runs/16842392256/job/47716140080?pr=232490#step:3:127
