### PR TITLE
don't link dependencies with conflicts

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -158,6 +158,7 @@ module Homebrew
           link_formula = Formulary.factory(name)
           next if link_formula.keg_only?
           next if link_formula.linked_keg.exist?
+          next if unlink_formulae.include?(name)
 
           test "brew", "link", name
         end


### PR DESCRIPTION
The new anyzig formula depends on the zig formula, but, it also conflicts_with it because they both install `zig` binaries. This works fine with brew but test-bot is failing because it's linking the dependency before installing, even with the conflict. The fix is to disable linking dependencies that are also marked as conflicts.