### PR TITLE
formulae_dependents: untap `homebrew/cask` when needed

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -33,6 +33,8 @@ module Homebrew
           []
         end
 
+        test "brew", "untap", "--force", "homebrew/cask" if !tap.core_cask_tap? && CoreCaskTap.instance.installed?
+
         @dependent_testing_formulae.each do |formula_name|
           dependent_formulae!(formula_name, args:)
           puts


### PR DESCRIPTION
Fixes Homebrew/brew#20527
