### PR TITLE
formulae_dependents: fix nil `tap`

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -33,7 +33,7 @@ module Homebrew
           []
         end
 
-        test "brew", "untap", "--force", "homebrew/cask" if !tap.core_cask_tap? && CoreCaskTap.instance.installed?
+        test "brew", "untap", "--force", "homebrew/cask" if !tap&.core_cask_tap? && CoreCaskTap.instance.installed?
 
         @dependent_testing_formulae.each do |formula_name|
           dependent_formulae!(formula_name, args:)


### PR DESCRIPTION
`tap` can be `nil` if `test-bot` is not run inside a tap. This could happen in `Homebrew/brew` tests.

Fixes https://github.com/Homebrew/brew/actions/runs/17122882076/job/48567797152.
