### PR TITLE
tests/formulae: ignore failures on /usr/sbin/purge

### DIFF
--- a/lib/tests/formulae.rb
+++ b/lib/tests/formulae.rb
@@ -542,7 +542,7 @@ module Homebrew
 
         if ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"].present? && OS.mac? && MacOS.version == :sequoia
           # Fix intermittent broken disk cache on Sequoia after building from source.
-          test "/usr/bin/sudo", "--non-interactive", "/usr/sbin/purge"
+          test "/usr/bin/sudo", "--non-interactive", "/usr/sbin/purge", ignore_failures: true
         end
 
         test "brew", "style", "--formula", formula_name, report_analytics: true


### PR DESCRIPTION
Trying to get avoid marking run as failed like in https://github.com/Homebrew/homebrew-core/actions/runs/17188430504/job/48760924021?pr=234231#step:3:559

```
Error: 2 failed steps!
sudo --non-interactive /usr/sbin/purge
sudo --non-interactive /usr/sbin/purge
Error: Process completed with exit code 1.
```