### PR TITLE
formulae_dependents: untap `homebrew/cask` earlier

### DIFF
--- a/lib/tests/formulae_dependents.rb
+++ b/lib/tests/formulae_dependents.rb
@@ -7,6 +7,8 @@ module Homebrew
       attr_writer :testing_formulae, :tested_formulae
 
       def run!(args:)
+        test "brew", "untap", "--force", "homebrew/cask" if !tap&.core_cask_tap? && CoreCaskTap.instance.installed?
+
         installable_bottles = @tested_formulae - @skipped_or_failed_formulae
         unneeded_formulae = @tested_formulae - @testing_formulae
         @skipped_or_failed_formulae += unneeded_formulae
@@ -32,8 +34,6 @@ module Homebrew
         else
           []
         end
-
-        test "brew", "untap", "--force", "homebrew/cask" if !tap&.core_cask_tap? && CoreCaskTap.instance.installed?
 
         @dependent_testing_formulae.each do |formula_name|
           dependent_formulae!(formula_name, args:)


### PR DESCRIPTION
The tapped `homebrew/cask` still seems to be causing issues in
Homebrew/core.[^1][^2]

Let's try to fix it by untapping homebrew/cask earlier.

[^1]: https://github.com/Homebrew/homebrew-core/pull/234498#issuecomment-3224665982
[^2]: https://github.com/Homebrew/homebrew-core/pull/234921#issuecomment-3222259437
